### PR TITLE
Improve Korean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,50 @@
 # Malware Pipeline
 
-This repository provides a skeleton implementation of a malware analysis pipeline. It includes directories for data processing, models, training pipelines and evaluation utilities.
+이 레포지토리는 악성코드 분석 및 모델 학습을 위한 파이프라인 예시를 제공합니다. 실제 동작 로직은 최소한으로 구현되어 있지만, 전체 흐름과 각 모듈이 맡는 역할을 쉽게 파악할 수 있도록 구성되어 있습니다.
 
-The code layout follows the provided project specification. Most modules currently contain only placeholders.
+## 파이프라인 요약
+1. **IR 추출**  
+   `data/raw/binaries` 디렉터리의 PE/ELF 파일에서 Ghidra와 llvm-mctoll을 호출하여 P-code와 LLVM IR을 생성합니다. 결과는 `data/ir/*.json`에 저장됩니다.
+2. **CPG 구성**  
+   P-code 또는 수도 코드 JSON을 파싱한 뒤, AST·CFG·DFG를 통합한 코드 속성 그래프(이기종 그래프)를 생성합니다. 추출된 그래프는 `data/cpg/`에 저장됩니다.
+3. **그래프 정규화**  
+   `graph_builder.py`가 CPG 혹은 IR 그래프를 읽어 노드/엣지를 정규화한 뒤 Parquet 형식(`data/graphs/`)으로 변환합니다. 더미 노드를 간략화하고 중요도가 낮은 부분을 잘라내는 필터가 포함됩니다.
+4. **그래프 임베딩 학습**  
+   `train_graphcl.py`는 PyTorch Geometric 기반 GNN을 사용해 함수 단위 임베딩을 학습합니다. GraphCL 방식의 대조 학습을 통해 더미 코드 삽입에도 불변인 표현을 얻습니다.
+5. **프로그램 임베딩**  
+   함수 임베딩 시퀀스를 `hier_transformer.py`에 입력하여 프로그램 단위 표현을 만듭니다. Hierarchical Distance-scaled Positional Encoding을 사용해 긴 제어 흐름도 안정적으로 처리합니다.
+6. **Capability 예측**  
+   `capability_head.py`는 프로그램 임베딩을 받아 20가지 악성 행위를 멀티라벨로 예측합니다.
+7. **RL 기반 규칙 수정**  
+   `models/rl/environment.py`와 `policy.py`는 PPO 에이전트를 구성합니다. 에이전트는 탐지 규칙을 편집하며, 보상 함수는 TPR과 FPR 차이를 기반으로 합니다.
+8. **CI 평가**  
+   `ci_runner.py`는 샘플 세트를 이용해 AUROC, FPR 변화를 측정하고 HTML 리포트를 만듭니다.
+
+## 주요 파일 설명
+| 경로 | 클래스/함수 | 입·출력 | 역할 |
+|-----|-------------|---------|------|
+|`src/data_proc/ir_extractor.py`|`IRExtractor`|PE/ELF → `ir/*.json`|Ghidra와 llvm-mctoll을 호출해 다중 IR을 추출합니다.|
+|`src/data_proc/graph_builder.py`|`GraphNormalizer`|IR/CPG → Parquet|그래프 정리 및 필터링을 수행하여 학습에 적합한 형식으로 변환합니다.|
+|`src/data_proc/dataset_loader.py`|`GraphDataset`|index → `HeteroData`|Parquet 그래프를 PyG 형식으로 로드합니다.|
+|`src/models/gnn/graphcl_encoder.py`|`GraphCLEncoder`|그래프 → (B,256)|GraphCL 대조 학습용 GNN 인코더의 기본 구조를 정의합니다.|
+|`src/models/transformer/hier_transformer.py`|`HierTransformer`|(B,L,256) → (B,256)|함수 임베딩 시퀀스로부터 프로그램 임베딩을 생성합니다.|
+|`src/models/heads/capability_head.py`|`CapabilityHead`|(B,256) → (B,20)|프로그램 임베딩을 20개 행위 점수로 변환하는 단순 MLP입니다.|
+|`src/models/rl/env.py`|`RuleEnv`|state ↔ action|PPO 학습을 위한 환경 정의를 위한 골격 코드입니다.|
+|`src/evaluation/ci_runner.py`|`run_ci`|rulebank → HTML|단순 무작위 데이터를 이용해 CI 리포트를 생성합니다.|
+
+현재 파일들은 대부분 최소한의 코드만 포함하고 있으나, 위 표와 같이 파이프라인 전체를 실험적으로 구현할 수 있는 구조를 갖추고 있습니다.
+
+## 실행 예시
+```bash
+# 의존성 설치 예
+pip install numpy
+
+# 간단한 CI 리포트 생성
+bash scripts/run_ci.sh
+```
+
+실행 후 `evaluation/ci_report.html`에서 AUROC 값과 차이를 확인할 수 있습니다.
+
+## TODO 주석
+이 저장소의 코드 대부분은 예시용 골격입니다. 실제 동작을 위해서는 각 파일에 포함된
+`TODO` 주석을 따라 세부 로직을 구현해야 합니다.

--- a/src/data_proc/dataset_loader.py
+++ b/src/data_proc/dataset_loader.py
@@ -22,6 +22,7 @@ class GraphDataset(Dataset):
         """Load a single graph represented as a dataframe."""
         path = self.files[idx]
         df = pd.read_parquet(path)
+        # TODO: convert parquet rows to PyG HeteroData object
         features = torch.tensor(
             df.drop(columns=["label"]).values, dtype=torch.float32
         )

--- a/src/data_proc/graph_builder.py
+++ b/src/data_proc/graph_builder.py
@@ -21,6 +21,7 @@ class GraphNormalizer:
         out_path = self.output_dir / f"{ir_path.stem}.parquet"
 
         data: Any = {}
+        # TODO: parse IR/CPG JSON and apply prune/centrality filters
         if ir_path.exists():
             try:
                 text = ir_path.read_text()
@@ -30,6 +31,7 @@ class GraphNormalizer:
 
         feat_1 = len(data)
         feat_2 = len(ir_path.name)
+        # TODO: compute real node features and labels
         df = pd.DataFrame({"feat1": [feat_1], "feat2": [feat_2], "label": [0]})
         df.to_parquet(out_path)
         return out_path

--- a/src/data_proc/ir_extractor.py
+++ b/src/data_proc/ir_extractor.py
@@ -15,6 +15,7 @@ class IRExtractor:
 
     def extract(self, binary_path: Path) -> List[Path]:
         logger.info("Extracting IR from %s", binary_path)
+        # TODO: replace with actual Ghidra and llvm-mctoll integration
         # In this simplified example we only create a dummy IR file
         out_file = self.output_dir / f"{binary_path.stem}.json"
         out_file.write_text("{}")

--- a/src/models/gnn/denoising_gcn.py
+++ b/src/models/gnn/denoising_gcn.py
@@ -8,5 +8,5 @@ class DenoisingGCN(nn.Module):
         self.layer = nn.Linear(hidden_dim, hidden_dim)
 
     def forward(self, x):
-        # Dummy implementation
+        # TODO: implement subgraph denoising logic
         return self.layer(x)

--- a/src/models/gnn/graphcl_encoder.py
+++ b/src/models/gnn/graphcl_encoder.py
@@ -19,4 +19,5 @@ class GraphCLEncoder(nn.Module):
             x = data.x
         else:
             x = torch.zeros(1, self.hidden_dim)
+        # TODO: add GraphCL augmentations and message passing
         return self.layer(x)

--- a/src/models/heads/capability_head.py
+++ b/src/models/heads/capability_head.py
@@ -7,4 +7,5 @@ class CapabilityHead(nn.Module):
         self.fc = nn.Linear(in_dim, num_labels)
 
     def forward(self, x):
+        # TODO: apply Focal-BCE loss during training
         return self.fc(x)

--- a/src/models/heads/dummy_head.py
+++ b/src/models/heads/dummy_head.py
@@ -10,4 +10,5 @@ class DummyHead(nn.Module):
         self.act = nn.Sigmoid()
 
     def forward(self, x):
+        # TODO: remove once real capability head is implemented
         return self.act(self.fc(x))

--- a/src/models/rl/env.py
+++ b/src/models/rl/env.py
@@ -1,6 +1,8 @@
 class RuleEnv:
     def reset(self):
+        # TODO: initialize environment state
         pass
 
     def step(self, action):
+        # TODO: update rules based on action and compute reward
         return {}, 0.0, True, {}

--- a/src/models/rl/policy.py
+++ b/src/models/rl/policy.py
@@ -1,3 +1,4 @@
 class RulePolicy:
     def act(self, state):
+        # TODO: return an action based on PPO policy
         return 0

--- a/src/models/transformer/hier_transformer.py
+++ b/src/models/transformer/hier_transformer.py
@@ -14,4 +14,5 @@ class HierTransformer(nn.Module):
 
     def forward(self, x):
         x = self.enc(x)
+        # TODO: add HDSE positional encoding and sparse attention
         return self.cls(x.mean(dim=1))

--- a/src/pipelines/preprocessing.py
+++ b/src/pipelines/preprocessing.py
@@ -13,4 +13,5 @@ def run(raw_dir: Path, graphs_dir: Path) -> None:
     for binary in raw_dir.glob('*'):
         ir_files = extractor.extract(binary)
         for ir in ir_files:
+            # TODO: parallelize and cache intermediate results
             normalizer.build(ir)

--- a/src/pipelines/train_embeddings.py
+++ b/src/pipelines/train_embeddings.py
@@ -17,6 +17,7 @@ def run(graphs_dir: Path, model_dir: Path) -> None:
         emb = gnn({"x": sample["x"]})
         prog = transformer(emb.unsqueeze(0))
         out = head(prog)
+        # TODO: accumulate loss and perform optimizer steps
 
     model_dir.mkdir(parents=True, exist_ok=True)
     path = model_dir / "graphcl_encoder.pt"

--- a/src/pipelines/train_rl_agent.py
+++ b/src/pipelines/train_rl_agent.py
@@ -6,5 +6,5 @@ from ..models.rl import RuleEnv, RulePolicy
 def run(graphs_dir: Path, labels: Path) -> None:
     env = RuleEnv()
     policy = RulePolicy()
-    # Placeholder RL loop
+    # TODO: implement PPO training loop with reward from environment
     env.reset()


### PR DESCRIPTION
## Summary
- clarify placeholder sections with TODO comments in the codebase
- mention TODO markers in README and remove stray prompt output

## Testing
- `pip install numpy`
- `bash scripts/run_ci.sh`


------
https://chatgpt.com/codex/tasks/task_e_68455ea453f4832ebd9830e110d2d78a