### PR TITLE
Add HDHG graph conversion and loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
    `data/raw/binaries` 디렉터리의 PE/ELF 파일에서 Ghidra와 llvm-mctoll을 호출하여 P-code와 LLVM IR을 생성합니다. 결과는 `data/ir/*.json`에 저장됩니다.
 2. **CPG 구성**  
    P-code 또는 수도 코드 JSON을 파싱한 뒤, AST·CFG·DFG를 통합한 코드 속성 그래프(이기종 그래프)를 생성합니다. 추출된 그래프는 `data/cpg/`에 저장됩니다.
-3. **그래프 정규화**  
-   `graph_builder.py`가 CPG 혹은 IR 그래프를 읽어 노드/엣지를 정규화한 뒤 Parquet 형식(`data/graphs/`)으로 변환합니다. 더미 노드를 간략화하고 중요도가 낮은 부분을 잘라내는 필터가 포함됩니다.
+3. **그래프 정규화**
+   `graph_builder.py`가 IR에서 추출한 코드를 파싱해 AST를 구축하고 HDHGN 논문의 HDHG 구조로 변환합니다. 결과 그래프는 PyTorch Geometric의 `HeteroData` 객체(`data/graphs/*.pt`)로 저장됩니다.
 4. **그래프 임베딩 학습**  
    `train_graphcl.py`는 PyTorch Geometric 기반 GNN을 사용해 함수 단위 임베딩을 학습합니다. GraphCL 방식의 대조 학습을 통해 더미 코드 삽입에도 불변인 표현을 얻습니다.
 5. **프로그램 임베딩**  
@@ -25,7 +25,7 @@
 |-----|-------------|-----------|-----------|
 |1. IR 추출|`src/data_proc/ir_extractor.py`|`Path`(PE/ELF)|`List[Path]` (`ir/*.json`)|
 |2. CPG 구성|별도 스크립트 없음|`ir/*.json`|CPG 그래프 `(V,E)`|
-|3. 그래프 정규화|`src/data_proc/graph_builder.py`|CPG 그래프|Parquet `(N,F)`|
+|3. 그래프 정규화|`src/data_proc/graph_builder.py`|CPG 그래프|HDHG `(HeteroData)`|
 |4. 그래프 임베딩 학습|`src/models/gnn/graphcl_encoder.py`|`(B,N,F)`|`(B,256)`|
 |5. 프로그램 임베딩|`src/models/transformer/hier_transformer.py`|`(B,L,256)`|`(B,256)`|
 |6. Capability 예측|`src/models/heads/capability_head.py`|`(B,256)`|`(B,20)`|
@@ -36,8 +36,8 @@
 | 경로 | 클래스/함수 | 입·출력 | 역할 |
 |-----|-------------|---------|------|
 |`src/data_proc/ir_extractor.py`|`IRExtractor`|PE/ELF → `ir/*.json`|Ghidra와 llvm-mctoll을 호출해 다중 IR을 추출합니다.|
-|`src/data_proc/graph_builder.py`|`GraphNormalizer`|IR/CPG → Parquet|그래프 정리 및 필터링을 수행하여 학습에 적합한 형식으로 변환합니다.|
-|`src/data_proc/dataset_loader.py`|`GraphDataset`|index → `HeteroData`|Parquet 그래프를 PyG 형식으로 로드합니다.|
+|`src/data_proc/graph_builder.py`|`GraphNormalizer`|IR → HDHG|AST를 HDHG 구조로 변환하고 `*.pt`로 저장합니다.|
+|`src/data_proc/dataset_loader.py`|`GraphDataset`|index → `HeteroData`|저장된 HDHG 그래프를 PyG 형식으로 로드합니다.|
 |`src/models/gnn/graphcl_encoder.py`|`GraphCLEncoder`|그래프 → (B,256)|GraphCL 대조 학습용 GNN 인코더의 기본 구조를 정의합니다.|
 |`src/models/transformer/hier_transformer.py`|`HierTransformer`|(B,L,256) → (B,256)|함수 임베딩 시퀀스로부터 프로그램 임베딩을 생성합니다.|
 |`src/models/heads/capability_head.py`|`CapabilityHead`|(B,256) → (B,20)|프로그램 임베딩을 20개 행위 점수로 변환하는 단순 MLP입니다.|

--- a/src/data_proc/__init__.py
+++ b/src/data_proc/__init__.py
@@ -1,0 +1,5 @@
+from .hdhg_builder import HDHGBuilder
+from .graph_builder import GraphNormalizer
+from .dataset_loader import GraphDataset
+from .ir_extractor import IRExtractor
+

--- a/src/data_proc/dataset_loader.py
+++ b/src/data_proc/dataset_loader.py
@@ -1,33 +1,31 @@
 from pathlib import Path
 from typing import Any, Dict
 
-import pandas as pd
 import torch
-
+from torch_geometric.data import HeteroData
 from torch.utils.data import Dataset
 
 
 class GraphDataset(Dataset):
-    """Load graphs stored in parquet format."""
+    """Load graphs stored as HDHG ``.pt`` files."""
 
     def __init__(self, root: Path, dummy_inject: bool = False):
         self.root = root
-        self.files = sorted(root.glob('*.parquet'))
+        self.files = sorted(root.glob('*.pt'))
         self.dummy_inject = dummy_inject
 
     def __len__(self) -> int:
         return len(self.files)
 
-    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
-        """Load a single graph represented as a dataframe."""
+    def __getitem__(self, idx: int) -> Dict[str, HeteroData]:
+        """Load a single graph represented as :class:`HeteroData`."""
         path = self.files[idx]
-        df = pd.read_parquet(path)
-        # TODO: convert parquet rows to PyG HeteroData object
-        features = torch.tensor(
-            df.drop(columns=["label"]).values, dtype=torch.float32
-        )
+        obj = torch.load(path, weights_only=False)
+        data: HeteroData = obj["data"]
         if self.dummy_inject:
-            noise = 0.1 * torch.randn_like(features)
-            features = features + noise
-        label = torch.tensor(int(df["label"].iloc[0]), dtype=torch.long)
-        return {"x": features, "y": label}
+            for key in data.node_types:
+                if "x" in data[key]:
+                    noise = 0.1 * torch.randn_like(data[key].x)
+                    data[key].x = data[key].x + noise
+        label = torch.tensor(int(obj.get("label", 0)), dtype=torch.long)
+        return {"data": data, "y": label}

--- a/src/data_proc/graph_builder.py
+++ b/src/data_proc/graph_builder.py
@@ -2,7 +2,9 @@ from pathlib import Path
 import json
 from typing import Any
 
-import pandas as pd
+import torch
+
+from .hdhg_builder import HDHGBuilder
 
 from ..common.logger import get_logger
 
@@ -15,23 +17,21 @@ class GraphNormalizer:
     def __init__(self, output_dir: Path):
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.hdhg_builder = HDHGBuilder()
 
     def build(self, ir_path: Path) -> Path:
         logger.info("Building graph from %s", ir_path)
-        out_path = self.output_dir / f"{ir_path.stem}.parquet"
+        out_path = self.output_dir / f"{ir_path.stem}.pt"
 
-        data: Any = {}
-        # TODO: parse IR/CPG JSON and apply prune/centrality filters
+        code = ""
         if ir_path.exists():
             try:
                 text = ir_path.read_text()
-                data = json.loads(text) if text else {}
+                data: Any = json.loads(text) if text else {}
+                code = data.get("code", "")
             except Exception:
-                data = {}
+                code = ""
 
-        feat_1 = len(data)
-        feat_2 = len(ir_path.name)
-        # TODO: compute real node features and labels
-        df = pd.DataFrame({"feat1": [feat_1], "feat2": [feat_2], "label": [0]})
-        df.to_parquet(out_path)
+        data_obj = self.hdhg_builder.from_code(code)
+        torch.save({"data": data_obj, "label": 0}, out_path)
         return out_path

--- a/src/data_proc/hdhg_builder.py
+++ b/src/data_proc/hdhg_builder.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import ast
+from typing import Dict, List, Tuple
+
+import torch
+from torch_geometric.data import HeteroData
+
+
+class HDHGBuilder:
+    """Convert Python AST to a simple HDHG represented as :class:`HeteroData`."""
+
+    def __init__(self) -> None:
+        self.node_types: Dict[str, int] = {}
+        self.edge_types: Dict[str, int] = {}
+
+    def _get_node_type(self, name: str) -> int:
+        if name not in self.node_types:
+            self.node_types[name] = len(self.node_types)
+        return self.node_types[name]
+
+    def _get_edge_type(self, name: str) -> int:
+        if name not in self.edge_types:
+            self.edge_types[name] = len(self.edge_types)
+        return self.edge_types[name]
+
+    def from_code(self, code: str) -> HeteroData:
+        tree = ast.parse(code)
+        nodes: List[int] = []
+        node_feats: List[List[int]] = []
+        edge_feats: List[List[int]] = []
+        tail_index: List[Tuple[int, int]] = []
+        head_index: List[Tuple[int, int]] = []
+
+        def add_node(node: ast.AST) -> int:
+            idx = len(nodes)
+            nodes.append(idx)
+            if isinstance(node, ast.Name):
+                t = self._get_node_type("identifier")
+            else:
+                t = self._get_node_type("ast")
+            node_feats.append([t])
+            return idx
+
+        def visit(node: ast.AST, parent: int | None = None, field: str | None = None) -> int:
+            idx = add_node(node)
+            children: List[int] = []
+            for f_name, value in ast.iter_fields(node):
+                if isinstance(value, ast.AST):
+                    children.append(visit(value, idx, f_name))
+                elif isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, ast.AST):
+                            children.append(visit(item, idx, f_name))
+            if parent is not None and field is not None:
+                e_idx = len(edge_feats)
+                et = self._get_edge_type(field)
+                edge_feats.append([et])
+                for child in children:
+                    tail_index.append((child, e_idx))
+                head_index.append((e_idx, parent))
+            return idx
+
+        visit(tree)
+
+        data = HeteroData()
+        data["node"].x = torch.tensor(node_feats, dtype=torch.long)
+        data["edge"].x = torch.tensor(edge_feats, dtype=torch.long) if edge_feats else torch.empty((0, 1), dtype=torch.long)
+        if tail_index:
+            tail = torch.tensor(list(zip(*tail_index)), dtype=torch.long)
+            data[("node", "tail", "edge")].edge_index = tail
+        if head_index:
+            head = torch.tensor(list(zip(*head_index)), dtype=torch.long)
+            data[("edge", "head", "node")].edge_index = head
+        return data

--- a/src/models/gnn/graphcl_encoder.py
+++ b/src/models/gnn/graphcl_encoder.py
@@ -15,8 +15,18 @@ class GraphCLEncoder(nn.Module):
         )
 
     def forward(self, data):
-        if hasattr(data, "x"):
-            x = data.x
+        """Encode a :class:`HeteroData` object."""
+        if hasattr(data, "node_types"):
+            feats = []
+            for t in data.node_types:
+                if "x" in data[t]:
+                    feats.append(data[t].x.float())
+            if feats:
+                x = torch.cat(feats, dim=0).mean(dim=0, keepdim=True)
+            else:
+                x = torch.zeros(1, self.hidden_dim)
+        elif hasattr(data, "x"):
+            x = data.x.float()
         else:
             x = torch.zeros(1, self.hidden_dim)
         # TODO: add GraphCL augmentations and message passing


### PR DESCRIPTION
## Summary
- implement `HDHGBuilder` to parse Python code into HDHG graph structure
- modify `GraphNormalizer` to generate `.pt` files storing HDHG graphs
- update `GraphDataset` to load these graphs and support noise injection
- adapt `GraphCLEncoder` for `HeteroData` input
- document HDHG pipeline changes in `README`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash scripts/run_ci.sh`

------
https://chatgpt.com/codex/tasks/task_e_684566390e4c832e843d9cfe1ceb9a46