### PR TITLE
Implement IR extraction via Ghidra and LLVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 이 레포지토리는 악성코드 분석 및 모델 학습을 위한 파이프라인 예시를 제공합니다. 실제 동작 로직은 최소한으로 구현되어 있지만, 전체 흐름과 각 모듈이 맡는 역할을 쉽게 파악할 수 있도록 구성되어 있습니다.
 
 ## 파이프라인 요약
-1. **IR 추출**  
-   `data/raw/binaries` 디렉터리의 PE/ELF 파일에서 Ghidra와 llvm-mctoll을 호출하여 P-code와 LLVM IR을 생성합니다. 결과는 `data/ir/*.json`에 저장됩니다.
+1. **IR 추출**
+   `data/raw/binaries` 디렉터리의 PE/ELF 파일에서 Ghidra와 llvm-mctoll을 호출하여 P-code와 LLVM IR을 생성합니다. 환경 변수 `GHIDRA_INSTALL_DIR`와 `LLVM_MCTOLL`를 설정하면 `ir_extractor.py`가 자동으로 두 도구를 찾습니다. 결과는 `data/ir/*.json`에 저장됩니다.
 2. **CPG 구성**  
    P-code 또는 수도 코드 JSON을 파싱한 뒤, AST·CFG·DFG를 통합한 코드 속성 그래프(이기종 그래프)를 생성합니다. 추출된 그래프는 `data/cpg/`에 저장됩니다.
 3. **그래프 정규화**
@@ -49,7 +49,7 @@
 ## 실행 예시
 ```bash
 # 의존성 설치 예
-pip install numpy
+pip install -r requirements.txt
 
 # 간단한 CI 리포트 생성
 bash scripts/run_ci.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+pandas
+pyyaml
+torch
+torch_geometric

--- a/src/data_proc/ghidra_scripts/export_pcode.py
+++ b/src/data_proc/ghidra_scripts/export_pcode.py
@@ -1,0 +1,37 @@
+#@author Malware Pipeline
+#@category Malware
+"""Export P-code for all functions as JSON."""
+
+import json
+from ghidra.app.decompiler import DecompInterface
+from ghidra.util.task import ConsoleTaskMonitor
+
+out_path = currentProgram.getName() + ".json"
+args = getScriptArgs()
+if args:
+    out_path = args[0]
+
+decomp = DecompInterface()
+decomp.openProgram(currentProgram)
+
+monitor = ConsoleTaskMonitor()
+fm = currentProgram.getFunctionManager()
+res = {}
+
+for func in fm.getFunctions(True):
+    r = decomp.decompileFunction(func, 60, monitor)
+    if not r.decompileCompleted():
+        continue
+    hf = r.getHighFunction()
+    if hf is None:
+        continue
+    ops = []
+    it = hf.getPcodeOps()
+    while it.hasNext():
+        op = it.next()
+        ops.append(str(op))
+    res[str(func.getEntryPoint())] = ops
+
+with open(out_path, "w") as f:
+    json.dump({"pcode": res}, f)
+

--- a/src/data_proc/ir_extractor.py
+++ b/src/data_proc/ir_extractor.py
@@ -1,3 +1,7 @@
+import json
+import os
+import subprocess
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -9,14 +13,58 @@ logger = get_logger(__name__)
 class IRExtractor:
     """Extract intermediate representations from binaries."""
 
-    def __init__(self, output_dir: Path):
+    def __init__(self, output_dir: Path, ghidra_dir: Path | None = None, llvm_mctoll: str = "llvm-mctoll"):
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.ghidra_dir = ghidra_dir or Path(os.environ.get("GHIDRA_INSTALL_DIR", ""))
+        self.llvm_mctoll = os.environ.get("LLVM_MCTOLL", llvm_mctoll)
+        self.script_dir = Path(__file__).parent / "ghidra_scripts"
 
     def extract(self, binary_path: Path) -> List[Path]:
         logger.info("Extracting IR from %s", binary_path)
-        # TODO: replace with actual Ghidra and llvm-mctoll integration
-        # In this simplified example we only create a dummy IR file
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_dir = Path(tmp)
+            pcode_json = tmp_dir / "pcode.json"
+            llvm_ir = tmp_dir / "llvm.ll"
+
+            if self.ghidra_dir.exists():
+                headless = self.ghidra_dir / "support" / "analyzeHeadless"
+                cmd = [
+                    str(headless),
+                    str(tmp_dir / "proj"),
+                    "tmp",
+                    "-import",
+                    str(binary_path),
+                    "-scriptPath",
+                    str(self.script_dir),
+                    "-postScript",
+                    "export_pcode.py",
+                    str(pcode_json),
+                    "-deleteProject",
+                ]
+                try:
+                    subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                except Exception as exc:
+                    logger.warning("Ghidra extraction failed: %s", exc)
+            else:
+                logger.warning("Ghidra directory not set; skipping P-code extraction")
+
+            try:
+                subprocess.run([self.llvm_mctoll, str(binary_path), "-o", str(llvm_ir)], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            except Exception as exc:
+                logger.warning("llvm-mctoll failed: %s", exc)
+
+            pcode_data = {}
+            if pcode_json.exists():
+                try:
+                    pcode_data = json.loads(pcode_json.read_text())
+                except Exception as exc:
+                    logger.warning("Failed to read P-code JSON: %s", exc)
+
+            llvm_text = llvm_ir.read_text() if llvm_ir.exists() else ""
+
         out_file = self.output_dir / f"{binary_path.stem}.json"
-        out_file.write_text("{}")
+        json.dump({"pcode": pcode_data.get("pcode", {}), "llvm_ir": llvm_text}, out_file.open("w"))
         return [out_file]
+


### PR DESCRIPTION
## Summary
- implement actual IRExtractor logic
- add headless Ghidra script for P-code export
- mention env vars in README
- introduce requirements file and update usage instructions

## Testing
- `python -m py_compile src/data_proc/ir_extractor.py src/data_proc/ghidra_scripts/export_pcode.py`
- `bash scripts/run_ci.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684637d8c01c832e8f1a2e2a71ffcd00