### PR TITLE
Improve preprocessing with caching and parallelism

### DIFF
--- a/src/pipelines/preprocessing.py
+++ b/src/pipelines/preprocessing.py
@@ -1,17 +1,69 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
+from typing import Dict, Tuple
 
 from ..common.logger import get_logger
-from ..data_proc.ir_extractor import IRExtractor
+from ..common.utils import sha256_file
 from ..data_proc.graph_builder import GraphNormalizer
+from ..data_proc.ir_extractor import IRExtractor
 
 logger = get_logger(__name__)
 
 
-def run(raw_dir: Path, graphs_dir: Path) -> None:
-    extractor = IRExtractor(raw_dir / 'ir')
-    normalizer = GraphNormalizer(graphs_dir)
-    for binary in raw_dir.glob('*'):
+def _process_binary(binary: Path, ir_dir: Path, graphs_dir: Path) -> str | None:
+    """Extract IR and build graphs for a single binary."""
+    try:
+        extractor = IRExtractor(ir_dir)
+        normalizer = GraphNormalizer(graphs_dir)
         ir_files = extractor.extract(binary)
+        out: Path | None = None
         for ir in ir_files:
-            # TODO: parallelize and cache intermediate results
-            normalizer.build(ir)
+            out = normalizer.build(ir)
+        return str(out) if out else None
+    except Exception as exc:  # pragma: no cover - simple logging
+        logger.error("Failed to process %s: %s", binary, exc)
+        return None
+
+
+def run(raw_dir: Path, graphs_dir: Path) -> None:
+    ir_dir = raw_dir / "ir"
+    graphs_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = graphs_dir / "manifest.json"
+    if manifest_path.exists():
+        manifest: Dict[str, str] = json.loads(manifest_path.read_text())
+    else:
+        manifest = {}
+
+    tasks: list[Tuple[Path, str]] = []
+    for binary in raw_dir.glob("*"):
+        if not binary.is_file():
+            continue
+        try:
+            digest = sha256_file(str(binary))
+        except Exception as exc:  # pragma: no cover - simple logging
+            logger.error("Failed to hash %s: %s", binary, exc)
+            continue
+
+        cached = manifest.get(digest)
+        if cached and Path(cached).exists():
+            logger.info("Skipping %s (cached)", binary)
+            continue
+        tasks.append((binary, digest))
+
+    with ProcessPoolExecutor() as exe:
+        future_map = {
+            exe.submit(_process_binary, b, ir_dir, graphs_dir): h for b, h in tasks
+        }
+        for future in as_completed(future_map):
+            file_hash = future_map[future]
+            try:
+                out_path = future.result()
+            except Exception as exc:  # pragma: no cover - simple logging
+                logger.error("Worker error for %s: %s", file_hash, exc)
+                continue
+            if out_path:
+                manifest[file_hash] = out_path
+                manifest_path.write_text(json.dumps(manifest, indent=2))


### PR DESCRIPTION
## Summary
- add parallel and cached graph construction
- integrate SHA256-based manifest and error handling

## Testing
- `bash scripts/run_ci.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68463a6ec058832e8acc9457a42e57da