### PR TITLE
Improve P-code extraction logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## 파이프라인 요약
 1. **IR 추출**
-   `data/raw/binaries` 디렉터리의 PE/ELF 파일에서 Ghidra와 llvm-mctoll을 호출하여 P-code와 LLVM IR을 생성합니다. 환경 변수 `GHIDRA_INSTALL_DIR`와 `LLVM_MCTOLL`를 설정하면 `ir_extractor.py`가 자동으로 두 도구를 찾습니다. 결과는 `data/ir/*.json`에 저장됩니다.
+   `data/raw/binaries` 디렉터리의 PE/ELF 파일에서 Ghidra와 llvm-mctoll을 호출하여 P-code와 LLVM IR을 생성합니다. 환경 변수 `GHIDRA_INSTALL_DIR`, `LLVM_MCTOLL`, `GHIDRA_TIMEOUT`를 설정하면 `ir_extractor.py`가 자동으로 두 도구를 찾고 타임아웃을 조절합니다. 생성된 P-code는 명령어, 입력, 출력 필드를 갖는 JSON으로 저장되며 결과 파일은 `data/ir/*.json`에 위치합니다.
 2. **CPG 구성**  
    P-code 또는 수도 코드 JSON을 파싱한 뒤, AST·CFG·DFG를 통합한 코드 속성 그래프(이기종 그래프)를 생성합니다. 추출된 그래프는 `data/cpg/`에 저장됩니다.
 3. **그래프 정규화**

--- a/src/data_proc/ghidra_scripts/export_pcode.py
+++ b/src/data_proc/ghidra_scripts/export_pcode.py
@@ -29,7 +29,9 @@ for func in fm.getFunctions(True):
     it = hf.getPcodeOps()
     while it.hasNext():
         op = it.next()
-        ops.append(str(op))
+        inputs = [str(op.getInput(i)) for i in range(op.getNumInputs())]
+        output = str(op.getOutput()) if op.getOutput() is not None else None
+        ops.append({"mnemonic": op.getMnemonic(), "inputs": inputs, "output": output})
     res[str(func.getEntryPoint())] = ops
 
 with open(out_path, "w") as f:

--- a/src/data_proc/hdhg_builder.py
+++ b/src/data_proc/hdhg_builder.py
@@ -115,16 +115,19 @@ class HDHGBuilder:
                 seen_nodes["function"].add(func_addr)
 
             prev_instr_id = None
-            for i, pcode_str in enumerate(pcode_list):
+            for i, inst in enumerate(pcode_list):
                 instr_id = f"{func_addr}_{i}"
                 if instr_id in seen_nodes["instruction"]:
                     continue
 
-                parts = pcode_str.replace(",", "").split()
-                opcode = parts[0] if parts and parts[0] in OPCODE_MAP else "UNKNOWN"
-                operands = parts[1:]
+                opcode = inst.get("mnemonic", "UNKNOWN")
+                if opcode not in OPCODE_MAP:
+                    opcode = "UNKNOWN"
+                inputs = inst.get("inputs", []) or []
+                output = inst.get("output")
+                operands = inputs + ([output] if output else [])
 
-                nodes["instruction"].append((instr_id, {"opcode": opcode, "text": pcode_str}))
+                nodes["instruction"].append((instr_id, {"opcode": opcode}))
                 seen_nodes["instruction"].add(instr_id)
 
                 edges[("function", "has_instruction", "instruction")].append((func_addr, instr_id))
@@ -133,7 +136,7 @@ class HDHGBuilder:
                 prev_instr_id = instr_id
 
                 for op in operands:
-                    if op.startswith("0x") or op.startswith("func_"):
+                    if not op or op.startswith("0x") or op.startswith("func_"):
                         continue
                     if op not in seen_nodes["variable"]:
                         nodes["variable"].append((op, {}))

--- a/src/data_proc/ir_extractor.py
+++ b/src/data_proc/ir_extractor.py
@@ -19,6 +19,7 @@ class IRExtractor:
         self.ghidra_dir = ghidra_dir or Path(os.environ.get("GHIDRA_INSTALL_DIR", ""))
         self.llvm_mctoll = os.environ.get("LLVM_MCTOLL", llvm_mctoll)
         self.script_dir = Path(__file__).parent / "ghidra_scripts"
+        self.ghidra_timeout = int(os.environ.get("GHIDRA_TIMEOUT", "60"))
 
     def extract(self, binary_path: Path) -> List[Path]:
         logger.info("Extracting IR from %s", binary_path)
@@ -44,14 +45,39 @@ class IRExtractor:
                     "-deleteProject",
                 ]
                 try:
-                    subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    subprocess.run(
+                        cmd,
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        timeout=self.ghidra_timeout,
+                    )
+                except subprocess.CalledProcessError as exc:
+                    logger.warning(
+                        "Ghidra extraction failed: %s\nstdout=%s\nstderr=%s",
+                        exc,
+                        exc.stdout.decode(errors="ignore"),
+                        exc.stderr.decode(errors="ignore"),
+                    )
                 except Exception as exc:
                     logger.warning("Ghidra extraction failed: %s", exc)
             else:
                 logger.warning("Ghidra directory not set; skipping P-code extraction")
 
             try:
-                subprocess.run([self.llvm_mctoll, str(binary_path), "-o", str(llvm_ir)], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                subprocess.run(
+                    [self.llvm_mctoll, str(binary_path), "-o", str(llvm_ir)],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            except subprocess.CalledProcessError as exc:
+                logger.warning(
+                    "llvm-mctoll failed: %s\nstdout=%s\nstderr=%s",
+                    exc,
+                    exc.stdout.decode(errors="ignore"),
+                    exc.stderr.decode(errors="ignore"),
+                )
             except Exception as exc:
                 logger.warning("llvm-mctoll failed: %s", exc)
 


### PR DESCRIPTION
## Summary
- rework Ghidra script to output structured JSON containing mnemonic, inputs and output
- capture Ghidra and llvm-mctoll logs in `IRExtractor` and support `GHIDRA_TIMEOUT`
- adapt `HDHGBuilder` to parse the new P-code format
- document new environment variable and structured P-code in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6846417208bc832eadca85f58bc7227f