### PR TITLE
Implement Focal Loss for capability head

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bash scripts/run_ci.sh
 `TODO` 주석을 따라 세부 로직을 구현해야 합니다.
 
 ### 현재 TODO 목록
-- `src/models/heads/capability_head.py`에서 Focal-BCE 손실 적용
+- `src/models/losses.py`에 Focal-BCE 손실 구현
 - `src/models/heads/dummy_head.py`를 실제 capability head 구현 후 제거
 - `src/models/rl/env.py`의 `reset` 및 `step` 로직 구현
 - `src/models/rl/policy.py`에 PPO 기반 정책 추가

--- a/src/models/heads/capability_head.py
+++ b/src/models/heads/capability_head.py
@@ -7,5 +7,6 @@ class CapabilityHead(nn.Module):
         self.fc = nn.Linear(in_dim, num_labels)
 
     def forward(self, x):
-        # TODO: apply Focal-BCE loss during training
+        """Return raw logits for each capability label."""
+        # The Focal-BCE loss is applied in the training pipeline
         return self.fc(x)

--- a/src/models/losses.py
+++ b/src/models/losses.py
@@ -1,0 +1,27 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class FocalLoss(nn.Module):
+    """Focal Loss for multi-label classification."""
+
+    def __init__(self, alpha: float = 0.25, gamma: float = 2.0, reduction: str = "mean"):
+        super().__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+        self.reduction = reduction
+
+    def forward(self, inputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        bce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
+        p = torch.sigmoid(inputs)
+        p_t = p * targets + (1 - p) * (1 - targets)
+        focal_term = (1.0 - p_t) ** self.gamma
+        loss = self.alpha * focal_term * bce_loss
+
+        if self.reduction == "mean":
+            return loss.mean()
+        if self.reduction == "sum":
+            return loss.sum()
+        return loss
+

--- a/src/pipelines/train_capability_model.py
+++ b/src/pipelines/train_capability_model.py
@@ -1,0 +1,37 @@
+import torch
+from pathlib import Path
+
+from ..models.heads import CapabilityHead
+from ..models.losses import FocalLoss
+
+
+def run(embeddings_path: Path, labels_path: Path) -> None:
+    """Train CapabilityHead with Focal-BCE loss.
+
+    Parameters
+    ----------
+    embeddings_path: Path
+        Path to tensor file containing program embeddings.
+    labels_path: Path
+        Path to tensor file with multi-label targets.
+    """
+
+    # TODO: replace the following dummy dataset with real loading logic
+    embeddings = torch.load(embeddings_path)
+    labels = torch.load(labels_path)
+    dataloader = list(zip(embeddings, labels))
+
+    model = CapabilityHead()
+    criterion = FocalLoss(alpha=0.25, gamma=2.0)
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
+
+    for x, y in dataloader:
+        optimizer.zero_grad()
+        logits = model(x)
+        loss = criterion(logits, y.float())
+        loss.backward()
+        optimizer.step()
+
+    # TODO: save the trained model
+    torch.save(model.state_dict(), "capability_head.pt")
+


### PR DESCRIPTION
## Summary
- add `FocalLoss` for multi-label classification
- use raw logits in `CapabilityHead`
- note loss implementation in README TODO list
- provide example training script using the new loss

## Testing
- `python -m py_compile src/models/losses.py src/models/heads/capability_head.py src/pipelines/train_capability_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846451ab0dc832e8679c48220c5a75e