### PR TITLE
Fix missing encoder path check

### DIFF
--- a/src/pipelines/train_dummy_detector.py
+++ b/src/pipelines/train_dummy_detector.py
@@ -27,8 +27,18 @@ def train_dummy_detector(cfg: DictConfig):
     # 2. 사전 학습된 GNN Encoder 로드
     # train_embeddings.py를 통해 학습된 모델의 경로를 인자로 받습니다.
     # GNN (Graph Neural Network) 인코더는 그래프 데이터를 벡터 형태로 변환하는 역할을 합니다.
-    encoder = GraphCLEncoder(in_dim=cfg.model.input_dim, hidden_dim=cfg.model.hidden_dim)
-    encoder.load_state_dict(torch.load(cfg.paths.encoder_path, map_location=device))
+    # 사전 학습된 인코더 경로가 실제로 존재하는지 확인합니다.
+    if not os.path.exists(cfg.paths.encoder_path):
+        raise FileNotFoundError(
+            f"GNN Encoder 체크포인트를 찾을 수 없습니다: {cfg.paths.encoder_path}"
+        )
+
+    encoder = GraphCLEncoder(
+        in_dim=cfg.model.input_dim, hidden_dim=cfg.model.hidden_dim
+    )
+    encoder.load_state_dict(
+        torch.load(cfg.paths.encoder_path, map_location=device)
+    )
     print("사전 학습된 GNN Encoder를 성공적으로 불러왔습니다.")
 
     # 3. GNN Encoder의 파라미터 동결


### PR DESCRIPTION
## Summary
- detect missing GNN encoder checkpoint before loading in `train_dummy_detector`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b8498564832e8a1a863918a7a905