### PR TITLE
Refactor builder responsibilities

### DIFF
--- a/src/data_proc/hdhg_builder.py
+++ b/src/data_proc/hdhg_builder.py
@@ -61,6 +61,30 @@ class HDHGBuilder:
         self.node_types: Dict[str, int] = {}
         self.edge_types: Dict[str, int] = {}
 
+    # ------------------------------------------------------------------ #
+    # Convenience dispatcher
+    # ------------------------------------------------------------------ #
+    def build(self, ir_data: Dict[str, Any]) -> HeteroData:
+        """Create an ``HeteroData`` graph from IR JSON.
+
+        Parameters
+        ----------
+        ir_data : dict
+            Loaded intermediate representation.
+
+        Returns
+        -------
+        HeteroData
+            Constructed graph or an empty graph when no supported data is
+            present.
+        """
+        if "pcode" in ir_data:
+            return self.from_pcode(ir_data)
+        code = ir_data.get("code")
+        if code:
+            return self.from_code(code)
+        return self.create_empty_graph()
+
     # -------------------------------------- #
     # 내부 헬퍼: 타입-ID 사전
     # -------------------------------------- #

--- a/src/pipelines/builder/graph_builder.py
+++ b/src/pipelines/builder/graph_builder.py
@@ -12,8 +12,10 @@ LOG = logging.getLogger(__name__)
 
 
 class GraphBuilder:
-    """
-    IR(중간 표현) JSON 파일을 입력받아 이기종 그래프(HeteroData)를 생성합니다.
+    """IR JSON 파일을 ``HeteroData`` 그래프로 변환합니다.
+
+    다른 후처리나 서브그래프 추출은 관여하지 않으며, 순수하게
+    :class:`HDHGBuilder` 를 이용해 전체 그래프 객체만 생성합니다.
     """
 
     def __init__(self, config: Config):
@@ -24,12 +26,8 @@ class GraphBuilder:
             config (Config): 파이프라인 설정 객체.
         """
         self.config = config
-        # 설정(config)을 기반으로 HDHGBuilder 인스턴스 생성
-        self.hdhg_builder = HDHGBuilder(
-            embed_dim=config.model.embed_dim,
-            const_truncate=config.graph.const_truncate,
-            max_bytes=config.graph.max_bytes
-        )
+        # HDHGBuilder는 그래프 생성 책임만 갖도록 단순화
+        self.hdhg_builder = HDHGBuilder()
 
     def build(self, ir_path: str) -> HeteroData:
         """

--- a/src/pipelines/orchestrator.py
+++ b/src/pipelines/orchestrator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 import torch
@@ -34,11 +35,15 @@ class Orchestrator:
     (torch_geometric HeteroData 버전)
     """
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, ir_dir: str | os.PathLike = "data/ir"):
+        """Initialize pipeline orchestrator."""
         self.config = config
+        self.ir_dir = os.fspath(ir_dir)
+        # GraphBuilder is responsible only for creating graphs
         self.builder = GraphBuilder(config)
-        self.labeler = GraphLabeler(config)
-        self.saver = GraphSaver(config)
+        self.labeler = GraphLabeler()
+        graphs_out = Path(config.data_dir) / "graphs"
+        self.saver = GraphSaver(graphs_out)
 
     # ════════════════════════════════════════════════════════════════
     # ▶ CHANGED: 벡터화·메모리 친화 k-hop 서브그래프 추출
@@ -109,7 +114,7 @@ class Orchestrator:
         for sample_id in tqdm(sample_ids):
             LOG.info(f"Processing sample: {sample_id}")
             try:
-                ir_path = os.path.join(self.config.data.ir_path, f"{sample_id}.json")
+                ir_path = os.path.join(self.ir_dir, f"{sample_id}.json")
                 if not os.path.exists(ir_path):
                     LOG.warning(f"IR file not found for {sample_id}, skipping.")
                     continue
@@ -123,11 +128,12 @@ class Orchestrator:
                 LOG.info(f"Found {num_functions} functions in {sample_id}.")
 
                 for func_idx in range(num_functions):
+                    graph_cfg = getattr(self.config, "graph", {})
                     subgraph = self._get_function_subgraph(
                         full_graph,
                         func_idx,
-                        num_hops=self.config.graph.radius,
-                        max_nodes=self.config.graph.get("max_nodes", 5_000),  # ▶ NEW
+                        num_hops=graph_cfg.get("radius", 10),
+                        max_nodes=graph_cfg.get("max_nodes", 5_000),
                     )
 
                     # 빈 그래프 fallback 덕분에 num_nodes == 0 상황 없음
@@ -152,12 +158,9 @@ class Orchestrator:
 
 
 if __name__ == "__main__":
-    config_path = "configs/base.yaml"
-    config = Config.from_yaml(config_path)
-    sample_ids = [
-        f.split(".")[0]
-        for f in os.listdir(config.data.ir_path)
-        if f.endswith(".json")
-    ]
-    orchestrator = Orchestrator(config)
+    config_path = "configs/paths.yaml"
+    config = Config.load(config_path)
+    ir_root = Path(config.data_dir) / "ir"
+    sample_ids = [p.stem for p in ir_root.glob("*.json")]
+    orchestrator = Orchestrator(config, ir_root)
     orchestrator.process(sample_ids)


### PR DESCRIPTION
## Summary
- simplify `GraphBuilder` to only create graphs via `HDHGBuilder`
- add `HDHGBuilder.build` helper for IR dispatching
- refactor `Orchestrator` to manage paths and use new builder
- adjust config loading in CLI example

## Testing
- `pip install yara-python --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b9223124832ea86998103c3953a3