### PR TITLE
Make desc training use hydra dataset paths

### DIFF
--- a/configs/preprocess_graphs.yaml
+++ b/configs/preprocess_graphs.yaml
@@ -1,0 +1,8 @@
+defaults:
+  - dataset_paths
+
+paths:
+  ir_dir: ${dataset_paths.dataset_root}/ir
+  label_dir: ${dataset_paths.dataset_root}/labels
+  out_dir: ${dataset_paths.dataset_root}/graphs_func
+fmt: gpickle

--- a/configs/train_embeddings.yaml
+++ b/configs/train_embeddings.yaml
@@ -1,6 +1,15 @@
-num_epochs: 50
-batch_size: 32
-learning_rate: 1e-3
-aug_ratio: 0.2
-contrastive_weight: 1.0
-classification_weight: 1.0
+defaults:
+  - dataset_paths
+
+training:
+  num_epochs: 50
+  batch_size: 32
+  learning_rate: 1e-3
+  aug_ratio: 0.2
+  contrastive_weight: 1.0
+  classification_weight: 1.0
+  mixed_precision: true
+
+paths:
+  graphs_dir: ${dataset_paths.dataset_root}/processed/graphs
+  model_dir: models

--- a/configs/train_lora_desc.yaml
+++ b/configs/train_lora_desc.yaml
@@ -1,4 +1,6 @@
 # @package _global_
+defaults:
+  - dataset_paths
 
 # 1. 학습 기본 설정
 training:
@@ -21,7 +23,7 @@ model:
 # 3. 데이터셋 경로 설정 (dataset_loader.py와 호환되어야 함)
 dataset:
   type: "description"
-  path: "data/processed/description_dataset" # (임베딩, 설명) 쌍이 저장된 경로
+  path: "${dataset_paths.dataset_root}/processed/description_dataset"
   splits:
     train: "train.json"
     validation: "val.json"

--- a/src/data_proc/generate_cooccurrence.py
+++ b/src/data_proc/generate_cooccurrence.py
@@ -4,7 +4,20 @@ import argparse
 import pandas as pd
 import numpy as np
 import os
+from pathlib import Path
+import yaml
 from tqdm import tqdm
+
+
+def _default_output_path() -> str:
+    """Return default output path based on dataset_paths.yaml."""
+    cfg_path = Path(__file__).resolve().parents[2] / "configs" / "dataset_paths.yaml"
+    if cfg_path.exists():
+        paths = yaml.safe_load(cfg_path.open())
+        root = paths.get("dataset_root", "data")
+    else:
+        root = "data"
+    return os.path.join(root, "labels", "co_occurrence.npy")
 
 
 def generate_cooccurrence_matrix(label_file: str, num_labels: int, output_path: str, threshold: float):
@@ -79,7 +92,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="라벨 공존 행렬 생성 스크립트")
     parser.add_argument('--label_file', type=str, required=True, help="라벨 정보가 포함된 CSV 파일 경로")
     parser.add_argument('--num_labels', type=int, required=True, help="데이터셋의 전체 라벨 개수")
-    parser.add_argument('--output_path', type=str, default='data/labels/co_occurrence.npy', help="생성된 .npy 파일을 저장할 경로")
+    parser.add_argument('--output_path', type=str, default=_default_output_path(),
+                        help="생성된 .npy 파일을 저장할 경로")
     parser.add_argument('--threshold', type=float, default=0.2, help="조건부 확률에 적용할 임계값")
 
     args = parser.parse_args()

--- a/src/pipelines/desc_training.py
+++ b/src/pipelines/desc_training.py
@@ -4,6 +4,7 @@ from transformers import AutoTokenizer, AdamW, get_scheduler
 from peft import PeftModel
 import hydra
 from omegaconf import DictConfig, OmegaConf
+from hydra.utils import to_absolute_path
 import os
 from tqdm import tqdm
 import json
@@ -59,7 +60,9 @@ class DescLoraTrainer:
         """학습 및 검증 데이터로더를 생성합니다."""
         self.logger.info("데이터셋 로드 중...")
         # 데이터셋은 (hdhg_embedding, text_description) 쌍으로 구성되어야 함
-        dataset_loader = DatasetLoader(self.config.dataset)
+        dataset_cfg = self.config.dataset
+        dataset_cfg.path = to_absolute_path(dataset_cfg.path)
+        dataset_loader = DatasetLoader(dataset_cfg)
         train_data = dataset_loader.get_split('train')
         val_data = dataset_loader.get_split('validation')
 

--- a/src/pipelines/preprocessing.py
+++ b/src/pipelines/preprocessing.py
@@ -7,6 +7,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, List
 
+import hydra
+from omegaconf import DictConfig
+from hydra.utils import to_absolute_path
+
 # NEW: orchestrator.process 사용
 from malware_pipeline.pipeline.orchestrator import process as build_label_save_graphs
 
@@ -14,9 +18,6 @@ from malware_pipeline.pipeline.orchestrator import process as build_label_save_g
 # ──────────────────────────────────────────────────────────────────────────────
 # 설정 & 헬퍼
 # ──────────────────────────────────────────────────────────────────────────────
-IR_ROOT = Path("data/ir")
-CAPA_ROOT = Path("data/labels")
-OUT_ROOT = Path("data/graphs_func")          # 함수 단위 그래프 저장 위치
 GRAPH_FMT = "gpickle"
 
 
@@ -29,10 +30,11 @@ def _collect_sample_ids(ir_root: Path) -> List[str]:
 # 공개 API
 # ──────────────────────────────────────────────────────────────────────────────
 def run(
+    *,
     sample_ids: Iterable[str] | None = None,
-    ir_root: Path = IR_ROOT,
-    capa_root: Path = CAPA_ROOT,
-    out_root: Path = OUT_ROOT,
+    ir_root: Path,
+    capa_root: Path,
+    out_root: Path,
     fmt: str = GRAPH_FMT,
 ) -> None:
     """
@@ -65,5 +67,15 @@ def run(
 # ──────────────────────────────────────────────────────────────────────────────
 # CLI 진입점 (선택)
 # ──────────────────────────────────────────────────────────────────────────────
+@hydra.main(version_base=None, config_path="../../configs", config_name="preprocess_graphs")
+def main(cfg: DictConfig) -> None:
+    run(
+        ir_root=Path(to_absolute_path(cfg.paths.ir_dir)),
+        capa_root=Path(to_absolute_path(cfg.paths.label_dir)),
+        out_root=Path(to_absolute_path(cfg.paths.out_dir)),
+        fmt=cfg.fmt,
+    )
+
+
 if __name__ == "__main__":
-    run()           # 파라미터를 바꾸고 싶다면 run(sample_ids=[...], ...)
+    main()

--- a/src/pipelines/train_embeddings.py
+++ b/src/pipelines/train_embeddings.py
@@ -8,7 +8,10 @@
 ✓ torch.cuda.amp.autocast + GradScaler → GPU 메모리 ↓, 학습 속도 ↑
 """
 from __future__ import annotations
-import yaml
+
+import hydra
+from omegaconf import DictConfig
+from hydra.utils import to_absolute_path
 from pathlib import Path
 from typing import List
 
@@ -22,22 +25,6 @@ from malware_pipeline.models import GraphCLEncoder, CapabilityHead
 from malware_pipeline.models.gnn.augmentations import drop_nodes, permute_edges
 from malware_pipeline.loss import FocalLoss
 
-# --------------------------------------------------------------------- #
-# 0. 하이퍼파라미터 ---------------------------------------------------- #
-_cfg_path = Path(__file__).resolve().parents[2] / "configs" / "train_embeddings.yaml"
-_cfg = yaml.safe_load(_cfg_path.open()) if _cfg_path.exists() else {}
-
-NUM_EPOCHS = _cfg.get("num_epochs",          50)
-BATCH_SIZE = _cfg.get("batch_size",          32)
-LR         = _cfg.get("learning_rate",       1e-3)
-AUG_RATIO  = _cfg.get("aug_ratio",           0.2)
-W_CONTR    = _cfg.get("contrastive_weight",  1.0)
-W_CLF      = _cfg.get("classification_weight", 1.0)
-USE_AMP    = _cfg.get("mixed_precision",     True)           # ── AMP toggle
-
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-if USE_AMP and DEVICE.type == "cuda":                        # (NEW, 권장)
-    torch.backends.cudnn.benchmark = True                    # 성능 hint
 
 # --------------------------------------------------------------------- #
 # 1. NT-Xent 대조 손실 -------------------------------------------------- #
@@ -60,8 +47,16 @@ def collate_graphs(samples: List[dict]):
 
 # --------------------------------------------------------------------- #
 # 3. 학습 루프 --------------------------------------------------------- #
-def run(graphs_dir: Path, model_dir: Path) -> None:
-    print("=== 임베딩 + 분류 헤드 학습 (AMP={}) ===".format(USE_AMP))
+def run(cfg: DictConfig) -> None:
+    use_amp = cfg.training.get("mixed_precision", True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if use_amp and device.type == "cuda":
+        torch.backends.cudnn.benchmark = True
+
+    graphs_dir = Path(to_absolute_path(cfg.paths.graphs_dir))
+    model_dir = Path(to_absolute_path(cfg.paths.model_dir))
+
+    print(f"=== 임베딩 + 분류 헤드 학습 (AMP={use_amp}) ===")
 
     # 3-1. 데이터 로딩
     dataset = GraphDataset(graphs_dir)
@@ -70,40 +65,40 @@ def run(graphs_dir: Path, model_dir: Path) -> None:
         return
     dataloader = torch.utils.data.DataLoader(
         dataset,
-        batch_size   = BATCH_SIZE,
+        batch_size   = cfg.training.batch_size,
         shuffle      = True,
         collate_fn   = collate_graphs,
         num_workers  = 4,
-        pin_memory   = (DEVICE.type == "cuda"),
+        pin_memory   = (device.type == "cuda"),
     )
 
     # 3-2. 모델, 손실, 옵티마이저, 스케일러
-    gnn  = GraphCLEncoder(in_dim=dataset.in_dim, hidden_dim=256, out_dim=256).to(DEVICE)
-    head = CapabilityHead(in_dim=256,         num_labels=dataset.num_labels).to(DEVICE)
+    gnn  = GraphCLEncoder(in_dim=dataset.in_dim, hidden_dim=256, out_dim=256).to(device)
+    head = CapabilityHead(in_dim=256,         num_labels=dataset.num_labels).to(device)
 
     criterion = FocalLoss()
     optimizer = torch.optim.Adam(
-        list(gnn.parameters()) + list(head.parameters()), lr=LR
+        list(gnn.parameters()) + list(head.parameters()), lr=cfg.training.learning_rate
     )
-    scaler = GradScaler(enabled=USE_AMP)                         # ── AMP
+    scaler = GradScaler(enabled=use_amp)                         # ── AMP
 
     # 3-3. Epoch loop
-    for epoch in range(1, NUM_EPOCHS + 1):
+    for epoch in range(1, cfg.training.num_epochs + 1):
         gnn.train(); head.train()
         epoch_loss_tot = epoch_loss_con = epoch_loss_clf = 0.0
 
         for graphs, y_multi in dataloader:                       # Batch, (B, C)
-            graphs  = graphs.to(DEVICE)
-            y_multi = y_multi.to(DEVICE).float()
+            graphs  = graphs.to(device)
+            y_multi = y_multi.to(device).float()
 
             # ── 데이터 증강 (view1, view2) ──────────────────────────────
-            view1 = [drop_nodes(d, AUG_RATIO)    for d in graphs.to_data_list()]
-            view2 = [permute_edges(d, AUG_RATIO) for d in graphs.to_data_list()]
-            view1_batch = Batch.from_data_list(view1).to(DEVICE)
-            view2_batch = Batch.from_data_list(view2).to(DEVICE)
+            view1 = [drop_nodes(d, cfg.training.aug_ratio)    for d in graphs.to_data_list()]
+            view2 = [permute_edges(d, cfg.training.aug_ratio) for d in graphs.to_data_list()]
+            view1_batch = Batch.from_data_list(view1).to(device)
+            view2_batch = Batch.from_data_list(view2).to(device)
 
             # ── Forward & Loss (AMP) ───────────────────────────────────
-            with autocast(enabled=USE_AMP):
+            with autocast(enabled=use_amp):
                 # contrastive views
                 z1 = gnn(view1_batch)           # (B, D)
                 z2 = gnn(view2_batch)           # (B, D)
@@ -114,7 +109,7 @@ def run(graphs_dir: Path, model_dir: Path) -> None:
 
                 loss_contrast = nt_xent_loss(z1, z2)
                 loss_clf      = criterion(logits, y_multi)
-                loss          = W_CONTR * loss_contrast + W_CLF * loss_clf
+                loss          = cfg.training.contrastive_weight * loss_contrast + cfg.training.classification_weight * loss_clf
 
             # ── Back-prop (scaled) ─────────────────────────────────────
             optimizer.zero_grad(set_to_none=True)
@@ -143,7 +138,10 @@ def run(graphs_dir: Path, model_dir: Path) -> None:
 
 # --------------------------------------------------------------------- #
 # 4. main -------------------------------------------------------------- #
+@hydra.main(version_base=None, config_path="../../configs", config_name="train_embeddings")
+def main(cfg: DictConfig) -> None:
+    run(cfg)
+
+
 if __name__ == "__main__":
-    graphs_path = Path("data/processed/graphs")
-    models_path = Path("models")
-    run(graphs_path, models_path)
+    main()


### PR DESCRIPTION
## Summary
- use absolute dataset paths in `desc_training.py`
- expose dataset root via Hydra defaults in `train_lora_desc.yaml`
- configure more pipelines via Hydra (`preprocessing.py`, `train_embeddings.py`)
- centralize GraphCL paths in `train_embeddings.yaml`
- load dataset root for co-occurrence script

## Testing
- `pip install yara-python`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849be4fb740832ebc3af625b5538fd1