### PR TITLE
Enable Hydra config for RL env weights

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -133,6 +133,7 @@ def train_rl(
     reward_weights: Annotated[str, typer.Option("--reward-weights", help="보상 가중치 예: '1.0,0.2,0.5'")] = "1.0,0.2,0.5",
     use_morl: bool = typer.Option(False, "--morl", help="다목적 RL(MORL-Baselines) 사용"),
     pref_batch: int = typer.Option(16, "--pref-batch", help="MORL: preference vector batch size"),
+    env_config: Path = typer.Option(Path("configs/rl_env.yaml"), "--env-config", help="RL 환경 설정 YAML"),
 ):
     """YARA 룰 생성을 위한 RL 에이전트를 학습시킵니다."""
     typer.echo(f"[INFO] Training RL agent ({algo})...")
@@ -159,6 +160,7 @@ def train_rl(
         reward_weights=weights,
         out_root=out_dir,
         pref_batch=pref_batch,
+        env_config=env_config,
     )
     typer.echo("[DONE] RL agent training complete.")
 

--- a/configs/rl_env.yaml
+++ b/configs/rl_env.yaml
@@ -1,1 +1,4 @@
 max_conditions: 5
+edge_cov_weight: 0.5
+conciseness_alpha: 1.0
+target_family_bonus: 1.0

--- a/src/models/rl/env.py
+++ b/src/models/rl/env.py
@@ -45,10 +45,6 @@ class RuleEnv(gym.Env):
 
     metadata = {"render_modes": ["human"]}
 
-    # --------------------------- 보상 가중치 ------------------------------ #
-    EDGE_COV_WEIGHT: float = 0.5      # 신규 CFG 엣지 커버리지 계수
-    CONCISENESS_ALPHA: float = 1.0    # 짧은 룰 보상 가중치
-    TARGET_FAMILY_BONUS: float = 1.0  # 지정 패밀리 탐지 보너스 계수
 
     # --------------------------------------------------------------------- #
     # 1‑1. 초기화
@@ -59,6 +55,9 @@ class RuleEnv(gym.Env):
         benign_db_path: str | Path,
         malicious_db_path: str | Path,
         max_rule_length: int = 5,
+        edge_cov_weight: float = 0.5,
+        conciseness_alpha: float = 1.0,
+        target_family_bonus: float = 1.0,
         *,
         validator: RuleValidator | None = None,
         reward_hook: Callable[[float, float, int, int], float] | None = None,
@@ -88,6 +87,9 @@ class RuleEnv(gym.Env):
         self.reward_hook = reward_hook
         self.target_families: List[str] = [s.lower() for s in (target_families or [])]
         self.max_rule_length = max_rule_length
+        self.edge_cov_weight = edge_cov_weight
+        self.conciseness_alpha = conciseness_alpha
+        self.target_family_bonus = target_family_bonus
 
         # ── ⑤ Gym spaces (Observation 고정)
         emb_dim = len(next(iter(self.features_data.values()))["embedding"])
@@ -198,11 +200,11 @@ class RuleEnv(gym.Env):
 
         # 1) 탐지 품질 + 커버리지
         default_reward = tpr - 10.0 * fpr
-        tpr_fpr_reward = default_reward + self.EDGE_COV_WEIGHT * new_edge_cov
+        tpr_fpr_reward = default_reward + self.edge_cov_weight * new_edge_cov
 
         # 2) Conciseness (짧을수록 ↑)
         rule_len = len(self.builder.strings)
-        conciseness_reward = self.CONCISENESS_ALPHA * (
+        conciseness_reward = self.conciseness_alpha * (
             1.0 - rule_len / self.max_rule_length
         )
 
@@ -222,7 +224,7 @@ class RuleEnv(gym.Env):
                 for p in matched_malware
             )
             if total_targets:
-                importance_reward = matched_targets / total_targets * self.TARGET_FAMILY_BONUS
+                importance_reward = matched_targets / total_targets * self.target_family_bonus
 
         # RewardHook (첫 성분 대체)
         if self.reward_hook is not None:

--- a/src/pipelines/train_rl_agent.py
+++ b/src/pipelines/train_rl_agent.py
@@ -20,6 +20,8 @@ import os
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple, Type
 
+from omegaconf import OmegaConf
+
 import gymnasium as gym
 import numpy as np
 import torch
@@ -134,6 +136,7 @@ def train_morl(
     out_dir: Path,
     seed: int | None,
     pref_batch: int,
+    env_config: Path,
 ):
     if PCPG is None:
         raise ImportError("morl-baselines 가 설치되지 않았습니다:  pip install morl-baselines")
@@ -172,15 +175,21 @@ def train(
     reward_weights: Tuple[float, float, float],
     out_root: Path,
     pref_batch: int,
+    env_config: Path,
 ):
     tag = "MORL" if use_morl else "SB3"
     run_dir = out_root / f"{tag}_{algo}_{dt.datetime.now().strftime('%Y%m%d-%H%M%S')}"
     run_dir.mkdir(parents=True, exist_ok=True)
 
+    env_cfg = OmegaConf.load(str(env_config))
     env_kwargs = dict(
         features_path=str(features),
         benign_db_path=str(benign_db),
         malicious_db_path=str(malicious_db),
+        max_rule_length=int(env_cfg.get("max_conditions", 5)),
+        edge_cov_weight=float(env_cfg.get("edge_cov_weight", 0.5)),
+        conciseness_alpha=float(env_cfg.get("conciseness_alpha", 1.0)),
+        target_family_bonus=float(env_cfg.get("target_family_bonus", 1.0)),
     )
     vec_cls = SubprocVecEnv if num_envs > 1 else DummyVecEnv
     base_env = vec_cls([make_env(env_kwargs, seed=seed + i if seed else None) for i in range(num_envs)])
@@ -194,6 +203,7 @@ def train(
             out_dir=run_dir,
             seed=seed,
             pref_batch=pref_batch,
+            env_config=env_config,
         )
     else:
         # 가중합 스칼라 → SB3
@@ -231,6 +241,8 @@ def cli() -> None:
     ap.add_argument("--morl", action="store_true", help="다목적 RL(MORL-Baselines) 사용")
     ap.add_argument("--pref-batch", default=16, type=int,
                     help="MORL : preference vector batch size")
+    ap.add_argument("--env-config", default=Path("configs/rl_env.yaml"), type=Path,
+                    help="환경 설정 YAML")
 
     args = ap.parse_args()
     torch.set_num_threads(max(os.cpu_count() // 2, 1))
@@ -247,6 +259,7 @@ def cli() -> None:
         reward_weights=tuple(args.weights),
         out_root=args.out,
         pref_batch=args.pref_batch,
+        env_config=args.env_config,
     )
 
 


### PR DESCRIPTION
## Summary
- add weights to `configs/rl_env.yaml`
- allow `RuleEnv` to receive weight values instead of class constants
- load `rl_env.yaml` in RL training pipeline
- expose env config option in CLI

## Testing
- `pip install yara-python==4.3.1`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9a850264832e8327ec3e37e63be0