### PR TITLE
Improve configuration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,11 @@
 | **8. 통합 탐지 모델**                       | `models/ensemble_detector.onnx`                                      | - 그래프-임베딩 + 룰-매칭 앙상블<br>- 실서비스 배포용 ONNX                      |
 | **9. 평가 & 리포트**                       | `reports/metrics_{date}.csv`<br>`reports/*.html` (Notebook)          | - Precision/Recall/F1, ROC, 오탐 케이스<br>- 실험 재현용 노트북           |
 | **10. 배포 산출물**                        | `docker/robust_malware_pipeline.tar`<br>`cli.py`, `requirements.txt` | - 컨테이너 이미지 & CLI 툴<br>- 내부 CI/CD 배포 대상으로 사용                  |
+
+---
+
+## Configuration Management
+
+- All major pipeline settings are now collected under `configs/config.yaml`.
+- Individual modules still keep their own YAML files and are loaded via Hydra `defaults`.
+- Paths such as the dataset root or label adjacency matrix are resolved through this central config, improving consistency.

--- a/cli.py
+++ b/cli.py
@@ -92,13 +92,30 @@ def train_capability(
     batch_size: int = typer.Option(32, "--batch", help="배치 크기"),
     lr: float = typer.Option(1e-3, "--lr", help="학습률"),
     adj_matrix: Path = typer.Option(
-        Path("data/labels/co_occurrence.npy"),
+        None,
         "--adj",
-        help="라벨 공존 행렬(.npy) 경로",
+        help="라벨 공존 행렬(.npy) 경로 (기본: config 기반)",
+    ),
+    config_yaml: Path = typer.Option(
+        Path("configs/config.yaml"),
+        "--config",
+        help="중앙 설정 파일 경로",
     ),
 ):
     """악성 역량 멀티라벨 분류기(CapabilityHead)를 학습시킵니다."""
     typer.echo("[INFO] Training CapabilityHead multi-label classifier...")
+    from omegaconf import OmegaConf
+    from hydra.utils import to_absolute_path
+
+    if config_yaml.exists():
+        cfg = OmegaConf.load(config_yaml)
+        dataset_root = cfg.get("dataset_paths", {}).get("dataset_root", "data")
+    else:
+        dataset_root = "data"
+
+    if adj_matrix is None:
+        adj_matrix = Path(to_absolute_path(str(Path(dataset_root) / "labels" / "co_occurrence.npy")))
+
     train_capability_run(
         embeddings_path,
         labels_path,

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,0 +1,13 @@
+# Central configuration for the malware pipeline
+# Each stage references its own sub-config via Hydra defaults
+
+defaults:
+  - paths
+  - dataset_paths
+  - preprocess_graphs
+  - train_embeddings
+  - train_dummy_detector
+  - train_capability_model
+  - train_lora_desc
+  - rl_env
+  - _self_

--- a/src/data_proc/generate_cooccurrence.py
+++ b/src/data_proc/generate_cooccurrence.py
@@ -5,19 +5,19 @@ import pandas as pd
 import numpy as np
 import os
 from pathlib import Path
-import yaml
+from omegaconf import OmegaConf
 from tqdm import tqdm
 
 
 def _default_output_path() -> str:
-    """Return default output path based on dataset_paths.yaml."""
-    cfg_path = Path(__file__).resolve().parents[2] / "configs" / "dataset_paths.yaml"
+    """Return default output path based on config.yaml."""
+    cfg_path = Path(__file__).resolve().parents[2] / "configs" / "config.yaml"
     if cfg_path.exists():
-        paths = yaml.safe_load(cfg_path.open())
-        root = paths.get("dataset_root", "data")
+        cfg = OmegaConf.load(cfg_path)
+        root = cfg.get("dataset_paths", {}).get("dataset_root", "data")
     else:
         root = "data"
-    return os.path.join(root, "labels", "co_occurrence.npy")
+    return str(Path(root) / "labels" / "co_occurrence.npy")
 
 
 def generate_cooccurrence_matrix(label_file: str, num_labels: int, output_path: str, threshold: float):


### PR DESCRIPTION
## Summary
- centralize settings in `configs/config.yaml`
- unify path handling in capability training command
- load default path for co-occurrence matrix from new config
- document configuration management strategy in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9c2f8b48832eae062fa503b826f5