### PR TITLE
Refactor CLI to load Hydra configs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -107,44 +107,31 @@ def train_dummy(
 
 @app.command()
 def train_capability(
-    embeddings_path: Path = typer.Option(..., "--embeddings", "-e", help="사전 계산된 임베딩 파일 (.pt)"),
-    labels_path: Path = typer.Option(..., "--labels", "-l", help="다중 라벨 정보 파일 (.pt)"),
-    model_out: Path = typer.Option(..., "--model-out", "-m", help="학습된 CapabilityHead 저장 경로"),
-    epochs: int = typer.Option(10, "--epochs", help="에포크 수"),
-    batch_size: int = typer.Option(32, "--batch", help="배치 크기"),
-    lr: float = typer.Option(1e-3, "--lr", help="학습률"),
-    adj_matrix: Path = typer.Option(
-        None,
-        "--adj",
-        help="라벨 공존 행렬(.npy) 경로 (기본: config 기반)",
-    ),
     config_yaml: Path = typer.Option(
-        Path("configs/config.yaml"),
-        "--config",
-        help="중앙 설정 파일 경로",
-    ),
+        Path("configs/config.yaml"), "--config", "-c", help="Hydra 설정 파일"
+    )
 ):
     """악성 역량 멀티라벨 분류기(CapabilityHead)를 학습시킵니다."""
     typer.echo("[INFO] Training CapabilityHead multi-label classifier...")
-    from omegaconf import OmegaConf
+
+    from hydra import compose, initialize
     from hydra.utils import to_absolute_path
 
-    if config_yaml.exists():
-        cfg = OmegaConf.load(config_yaml)
-        dataset_root = cfg.get("dataset_paths", {}).get("dataset_root", "data")
-    else:
-        dataset_root = "data"
+    with initialize(version_base=None, config_path=str(config_yaml.parent)):
+        cfg = compose(config_name=config_yaml.stem)
 
-    if adj_matrix is None:
-        adj_matrix = Path(to_absolute_path(str(Path(dataset_root) / "labels" / "co_occurrence.npy")))
+    embeddings_path = Path(to_absolute_path(cfg.paths.embeddings))
+    labels_path = Path(to_absolute_path(cfg.paths.labels))
+    model_out = Path(to_absolute_path(cfg.paths.checkpoint))
+    adj_matrix = Path(to_absolute_path(cfg.paths.adj_matrix))
 
     train_capability_run(
         embeddings_path,
         labels_path,
         model_out,
-        epochs,
-        batch_size,
-        lr,
+        cfg.training.num_epochs,
+        cfg.training.batch_size,
+        cfg.training.learning_rate,
         adj_matrix,
     )
     typer.echo(f"[DONE] CapabilityHead model saved to {model_out}")
@@ -228,7 +215,8 @@ def describe_code(
 @app.command()
 def detect_function(
     input_path: Path = typer.Option(..., "--input", "-i", help="분석할 함수 바이너리 파일 경로"),
-    model_path: Path = typer.Option(..., "--model", "-m", help="학습된 GNN 인코더 모델 파일 경로")
+    model_path: Path = typer.Option(..., "--model", "-m", help="학습된 GNN 인코더 모델 파일 경로"),
+    config_yaml: Path = typer.Option(Path("configs/config.yaml"), "--config", help="Hydra 설정 파일")
 ):
     """
     주어진 함수 바이너리로부터 그래프를 생성하고, 학습된 모델로 악성 여부를 탐지합니다.
@@ -249,7 +237,16 @@ def detect_function(
 
     # 1. 설정 로드
     try:
-        cfg = Config.load("configs/paths.yaml")
+        from hydra import compose, initialize
+        from hydra.utils import to_absolute_path
+
+        with initialize(version_base=None, config_path=str(config_yaml.parent)):
+            hydra_cfg = compose(config_name=config_yaml.stem)
+
+        cfg = Config(
+            data_dir=Path(to_absolute_path(hydra_cfg.data_dir)),
+            model_dir=Path(to_absolute_path(hydra_cfg.model_dir)),
+        )
     except Exception as exc:  # noqa: BLE001
         LOG.error("Failed to load configuration: %s", exc)
         typer.echo("Configuration loading failed.", err=True)


### PR DESCRIPTION
## Summary
- remove hardcoded paths in `train_capability` and `detect_function`
- load settings via Hydra compose using the central config

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'yara')*

------
https://chatgpt.com/codex/tasks/task_e_684aa0a1d904832eb1ef21abf8b35b3d