### PR TITLE
Improve CLI guidance and orchestrator integration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,18 +13,23 @@ from src.common.logger import get_logger
 # Import project modules
 from src.pipelines.orchestrator import Orchestrator
 from src.common.config import Config  # Config loader (for YAML configs)
-from src.pipelines.train_hdhg_embeddings import train as train_hdhg
 from src.pipelines.train_dummy_detector import train_dummy_detector
-from src.pipelines.train_capability_model import run as train_capability_run
 from src.data_proc.generate_cooccurrence import generate_cooccurrence_matrix
 from src.models.gnn.graphcl_encoder import GraphCLEncoder
-from src.models.heads.classification_head import ClassificationHead
 # RL 학습 스크립트와 이름이 충돌하지 않도록 별칭 사용
 from src.pipelines.train_rl_agent import train as rl_agent_train
 from src.data_proc.ir_extractor import IRExtractor
 from src.pipelines.builder.graph_builder import GraphBuilder
 
-app = typer.Typer(help="Malware Pipeline CLI interface")
+app = typer.Typer(
+    help=
+    """Malware Pipeline CLI interface.
+
+    Typical workflow:\n"
+    "  1. preprocess  → graphs/\n"
+    "  2. train-gnn   → embeddings/\n"
+    "  3. train-capability (uses embeddings from step 2)"""
+)
 LOG = get_logger(__name__)
 logging.basicConfig(level=logging.INFO)
 
@@ -53,9 +58,9 @@ def preprocess(
     radius: int = typer.Option(2, help="함수 서브그래프 추출 시 반경(k-hop)"),
     config_path: Path = typer.Option(None, "--config", help="파이프라인 설정 YAML 파일")
 ):
-    """
-    IR JSON 파일로부터 함수 단위 그래프를 생성하고 라벨을 부착하여 저장합니다.
-    Orchestrator를 사용하여 전체 프로그램 그래프를 만들고, 각 함수의 k-hop 서브그래프를 추출한 뒤 라벨링하여 저장합니다.
+    """Step 1: IR → function graphs.
+
+    생성된 그래프(`graphs/`)는 이후 ``train-gnn`` 단계에서 사용됩니다.
     """
     if config_path and config_path.exists():
         cfg = Config.load(str(config_path))
@@ -91,9 +96,14 @@ def train_gnn(
     graphs_dir: Path = typer.Option(..., "--graphs", "-g", help="함수 그래프(.pt) 디렉터리"),
     model_out: Path = typer.Option(..., "--model-out", "-m", help="학습된 GNN 인코더 저장 디렉터리")
 ):
-    """그래프 대조 학습(GraphCL)으로 GNN 인코더를 학습시킵니다."""
+    """Step 2: GraphCL encoder training.
+
+    ``preprocess`` 단계에서 생성된 그래프를 입력으로 받아
+    임베딩(`embeds/`)을 생성합니다.
+    """
     typer.echo("[INFO] Training GNN encoder (contrastive learning)...")
-    train_hdhg(graphs_dir, model_out)
+    orchestrator = Orchestrator(Config(data_dir=graphs_dir.parent, model_dir=model_out))
+    orchestrator.train_gnn(graphs_dir, model_out)
     typer.echo(f"[DONE] GNN encoder saved to {model_out}/hdhgn_encoder.pt")
 
 @app.command()
@@ -111,30 +121,14 @@ def train_capability(
         Path("configs/config.yaml"), "--config", "-c", help="Hydra 설정 파일"
     )
 ):
-    """악성 역량 멀티라벨 분류기(CapabilityHead)를 학습시킵니다."""
+    """Step 3: Capability classifier training.
+
+    ``train-gnn`` 단계에서 생성된 임베딩을 입력으로 사용합니다.
+    """
     typer.echo("[INFO] Training CapabilityHead multi-label classifier...")
-
-    from hydra import compose, initialize
-    from hydra.utils import to_absolute_path
-
-    with initialize(version_base=None, config_path=str(config_yaml.parent)):
-        cfg = compose(config_name=config_yaml.stem)
-
-    embeddings_path = Path(to_absolute_path(cfg.paths.embeddings))
-    labels_path = Path(to_absolute_path(cfg.paths.labels))
-    model_out = Path(to_absolute_path(cfg.paths.checkpoint))
-    adj_matrix = Path(to_absolute_path(cfg.paths.adj_matrix))
-
-    train_capability_run(
-        embeddings_path,
-        labels_path,
-        model_out,
-        cfg.training.num_epochs,
-        cfg.training.batch_size,
-        cfg.training.learning_rate,
-        adj_matrix,
-    )
-    typer.echo(f"[DONE] CapabilityHead model saved to {model_out}")
+    orchestrator = Orchestrator(Config(data_dir=Path.cwd(), model_dir=Path.cwd()))
+    orchestrator.train_capability(config_yaml)
+    typer.echo("[DONE] CapabilityHead training complete.")
 
 @app.command()
 def train_desc(

--- a/src/pipelines/orchestrator.py
+++ b/src/pipelines/orchestrator.py
@@ -23,6 +23,8 @@ from src.common.config import Config
 from src.pipelines.builder.graph_builder import GraphBuilder
 from src.pipelines.io.graph_saver import GraphSaver
 from src.pipelines.labeling.graph_labeler import GraphLabeler
+from src.pipelines.train_hdhg_embeddings import train as train_hdhg
+from src.pipelines.train_capability_model import run as train_capability_run
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
@@ -155,6 +157,36 @@ class Orchestrator:
 
             except Exception as e:
                 LOG.error(f"Failed to process {sample_id}: {e}", exc_info=True)
+
+    # -----------------------------------------------------------------
+    # 학습 단계 호출을 위한 래퍼 메서드들
+    # -----------------------------------------------------------------
+    def train_gnn(self, graphs_dir: Path, model_out: Path) -> None:
+        """Run GraphCL encoder training on preprocessed graphs."""
+        train_hdhg(graphs_dir, model_out)
+
+    def train_capability(self, config_yaml: Path) -> None:
+        """Train capability classifier using graph embeddings."""
+        from hydra import compose, initialize
+        from hydra.utils import to_absolute_path
+
+        with initialize(version_base=None, config_path=str(config_yaml.parent)):
+            cfg = compose(config_name=config_yaml.stem)
+
+        embeddings_path = Path(to_absolute_path(cfg.paths.embeddings))
+        labels_path = Path(to_absolute_path(cfg.paths.labels))
+        model_out = Path(to_absolute_path(cfg.paths.checkpoint))
+        adj_matrix = Path(to_absolute_path(cfg.paths.adj_matrix))
+
+        train_capability_run(
+            embeddings_path,
+            labels_path,
+            model_out,
+            cfg.training.num_epochs,
+            cfg.training.batch_size,
+            cfg.training.learning_rate,
+            adj_matrix,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clarify pipeline order in CLI help
- describe inputs and outputs for preprocessing and training commands
- route training stages through the Orchestrator
- add orchestrator wrappers for GNN and capability training

## Testing
- `pip install yara-python`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa2c82848832ebe2686564aaef6df