### PR TITLE
Improve IR extraction and per-function graph handling

### DIFF
--- a/src/data_proc/graph_builder.py
+++ b/src/data_proc/graph_builder.py
@@ -115,6 +115,7 @@ class GraphNormalizer:
                     func_addr,
                     err,
                 )
+                continue
 
         if not written:
             logger.warning("No function graphs produced for %s", ir_path)

--- a/src/data_proc/ir_extractor.py
+++ b/src/data_proc/ir_extractor.py
@@ -150,6 +150,10 @@ class IRExtractor:
 
             llvm_text = llvm_ir.read_text() if llvm_ir.exists() else ""
 
+        if not pcode_data.get("pcode") and not llvm_text:
+            logger.error("IR extraction failed completely for %s", binary_path)
+            return []
+
         logger.debug(
             "Writing combined IR json with %d bytes of llvm IR", len(llvm_text)
         )


### PR DESCRIPTION
## Summary
- avoid writing empty IR JSON when extraction fails
- continue graph building even if a single function fails

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa4b51b80832eb82d016fc4bdb703