### PR TITLE
Add graph and CLI tests with skips for optional deps

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -1,0 +1,15 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+Data = pytest.importorskip("torch_geometric.data", minversion="0").Data
+
+from src.models.gnn.augmentations import drop_nodes, permute_edges
+
+def test_drop_nodes_and_permute_edges():
+    x = torch.randn(5, 4)
+    edge_index = torch.tensor([[0,1,2,3,4],[1,2,3,4,0]])
+    data = Data(x=x, edge_index=edge_index)
+    dropped = drop_nodes(data, 0.4)
+    assert dropped.num_nodes <= data.num_nodes
+    permuted = permute_edges(data, 0.4, add_same_number=False)
+    assert permuted.edge_index.size(1) <= data.edge_index.size(1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import pytest
+
+typer = pytest.importorskip("typer")
+CliRunner = pytest.importorskip("typer.testing").CliRunner
+pytest.importorskip("torch_scatter")
+
+from cli import app
+
+
+def test_detect_invalid_input(tmp_path: Path):
+    model = tmp_path / "model.pt"
+    model.write_bytes(b"dummy")
+    runner = CliRunner()
+    result = runner.invoke(app, ["detect-function", "--input", str(tmp_path/"no.bin"), "--model", str(model)])
+    assert result.exit_code != 0
+    assert "input file not found" in result.stdout.lower()

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("torch_geometric")
+from src.data_proc.graph_builder import GraphNormalizer
+
+
+def test_build_empty_or_corrupt(tmp_path: Path):
+    empty = tmp_path / "empty.json"
+    empty.write_text("")
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{invalid")
+    out_dir = tmp_path / "out"
+    gb = GraphNormalizer(out_dir)
+    assert gb.build(empty) == []
+    assert gb.build(corrupt) == []
+
+
+def test_build_monolithic(tmp_path: Path):
+    ir = tmp_path / "sample.json"
+    ir.write_text(json.dumps({"code": ""}))
+    out_dir = tmp_path / "out"
+    gb = GraphNormalizer(out_dir)
+    paths = gb.build(ir)
+    assert len(paths) == 1
+    saved = torch.load(paths[0], weights_only=False)
+    assert "data" in saved and "label" in saved

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,10 @@
+import pytest
+from pathlib import Path
+
+pytest.importorskip("yara")
+
 from src.rules.rule_builder import RuleBuilder
 from src.rules.rule_validator import RuleValidator
-from pathlib import Path
 
 def test_builder_roundtrip():
     rb = RuleBuilder("test")


### PR DESCRIPTION
## Summary
- test GraphNormalizer on empty/corrupt IR files and monolithic graphs
- test basic graph augmentation utilities
- test CLI invalid input behaviour
- skip rule tests when `yara` is not installed
- configure test path in `conftest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aaa1c7b5c832ea14814b3f62223da