### PR TITLE
Enable config-driven graph augmentations

### DIFF
--- a/configs/augmentations.yaml
+++ b/configs/augmentations.yaml
@@ -1,0 +1,9 @@
+model:
+  augmentations:
+    - name: drop_nodes
+      p: 0.5
+    - name: permute_edges
+      p: 0.5
+    - name: subgraph_sampling
+      p: 0.3
+  num_aug_strategies: 2

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,6 +4,7 @@
 defaults:
   - paths
   - dataset_paths
+  - augmentations
   - preprocess_graphs
   - train_embeddings
   - train_dummy_detector

--- a/configs/train_embeddings.yaml
+++ b/configs/train_embeddings.yaml
@@ -12,6 +12,7 @@
 # 기본 설정: Hydra의 기본값 사용
 defaults:
   - _self_
+  - augmentations
 
 # --- 1. 경로 설정 (Paths Configuration) ---
 # 프로젝트의 모든 데이터 및 산출물 경로를 관리합니다.

--- a/src/models/gnn/augmentations.py
+++ b/src/models/gnn/augmentations.py
@@ -11,7 +11,7 @@ Graph-level Data Augmentations
 """
 
 from __future__ import annotations
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Callable, Sequence
 
 import torch
 import torch.nn.functional as F
@@ -22,6 +22,7 @@ from torch_geometric.utils import (
     to_undirected,
 )
 from torch_scatter import scatter_mean
+import random
 
 
 # ════════════════════════════════════════════════════════════
@@ -197,6 +198,45 @@ def shuffle_functions(
 
 
 # ════════════════════════════════════════════════════════════
+# Registry & Applier  ────────────────────────────────────────
+# ════════════════════════════════════════════════════════════
+
+# Mapping from string names to augmentation callables
+AUGMENTATION_REGISTRY: dict[str, Callable[[Data], Data]] = {
+    "drop_nodes": drop_nodes,
+    "permute_edges": permute_edges,
+    "attribute_masking": attribute_masking,
+    "subgraph_sampling": subgraph_sampling,
+    "insert_nop_nodes": insert_nop_nodes,
+    "shuffle_functions": shuffle_functions,
+}
+
+
+class AugmentationApplier:
+    """Apply configured augmentations randomly."""
+
+    def __init__(self, strategies: Sequence[dict], num_to_apply: int = 2) -> None:
+        self.num_to_apply = num_to_apply
+        self.strategies: list[tuple[Callable[[Data], Data], float]] = []
+        for cfg in strategies:
+            func = AUGMENTATION_REGISTRY.get(cfg.get("name"))
+            if func is not None:
+                prob = float(cfg.get("p", 1.0))
+                self.strategies.append((func, prob))
+
+    def apply(self, data: Data) -> Data:
+        if not self.strategies:
+            return data.clone()
+        n = min(self.num_to_apply, len(self.strategies))
+        chosen = random.sample(self.strategies, k=n)
+        out = data.clone()
+        for func, prob in chosen:
+            if random.random() < prob:
+                out = func(out)
+        return out
+
+
+# ════════════════════════════════════════════════════════════
 # 4. 전체 EXPORTS
 # ════════════════════════════════════════════════════════════
 __all__ = [
@@ -209,4 +249,6 @@ __all__ = [
     # Marvolo
     "insert_nop_nodes",
     "shuffle_functions",
+    "AUGMENTATION_REGISTRY",
+    "AugmentationApplier",
 ]

--- a/src/models/gnn/graphcl_encoder.py
+++ b/src/models/gnn/graphcl_encoder.py
@@ -7,7 +7,7 @@ from torch_geometric.nn import global_mean_pool
 
 # --- 변경점 1: augmentation.py에서 증강 함수 임포트 ---
 # 코드 중복을 피하고 모듈화를 위해 기존에 정의된 증강 함수를 직접 임포트합니다.
-from .augmentations import drop_nodes, permute_edges
+from .augmentations import drop_nodes, permute_edges, AugmentationApplier
 # ----------------------------------------------------
 
 # --- 변경점 2: DenoisingGCN 임포트 ---
@@ -22,7 +22,15 @@ class GraphCLEncoder(torch.nn.Module):
     DenoisingGCN을 백본으로 사용하고, augmentations.py의 증강 함수를 활용하는 GraphCL 인코더.
     """
 
-    def __init__(self, in_dim: int = 256, hidden_dim: int = 256):
+    def __init__(
+        self,
+        in_dim: int = 256,
+        hidden_dim: int = 256,
+        out_dim: int | None = None,
+        *,
+        aug_configs: list[dict] | None = None,
+        num_aug_strategies: int = 2,
+    ):
         super().__init__()
 
         # GNN 백본으로 DenoisingGCN 레이어를 사용합니다.
@@ -30,7 +38,14 @@ class GraphCLEncoder(torch.nn.Module):
         self.conv2 = DenoisingGCN(hidden_dim=hidden_dim)  # hidden_dim -> hidden_dim
 
         # 투영 헤드(Projection Head)
-        self.proj_head = torch.nn.Linear(hidden_dim, hidden_dim)
+        self.proj_head = torch.nn.Linear(hidden_dim, out_dim or hidden_dim)
+
+        if aug_configs is not None:
+            self.augmentation_applier = AugmentationApplier(
+                aug_configs, num_to_apply=num_aug_strategies
+            )
+        else:
+            self.augmentation_applier = None
 
     def _prepare(self, data: Data | HeteroData) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         """PyG의 Data 또는 HeteroData 객체를 동형(homogeneous) 그래프 텐서로 변환합니다."""
@@ -80,13 +95,12 @@ class GraphCLEncoder(torch.nn.Module):
         data_view1 = data.clone()
         data_view2 = data.clone()
 
-        # 증강 1: 노드 제거 (Drop Nodes)
-        # drop_nodes 함수는 Data 객체를 받아 수정된 Data 객체를 반환합니다.
-        augmented_view1 = drop_nodes(data_view1, aug_ratio)
-
-        # 증강 2: 엣지 교란 (Permute Edges)
-        # permute_edges 함수 역시 Data 객체를 받아 수정된 Data 객체를 반환합니다.
-        augmented_view2 = permute_edges(data_view2, aug_ratio)
+        if self.augmentation_applier is not None:
+            augmented_view1 = self.augmentation_applier.apply(data_view1)
+            augmented_view2 = self.augmentation_applier.apply(data_view2)
+        else:
+            augmented_view1 = drop_nodes(data_view1, aug_ratio)
+            augmented_view2 = permute_edges(data_view2, aug_ratio)
 
         # 각 증강된 그래프에 대해 GNN 인코딩 수행
         z1 = self.forward(augmented_view1)

--- a/src/pipelines/train_embeddings.py
+++ b/src/pipelines/train_embeddings.py
@@ -22,7 +22,7 @@ from torch_geometric.data import Batch, Data
 
 from malware_pipeline.data import GraphDataset
 from malware_pipeline.models import GraphCLEncoder, CapabilityHead
-from malware_pipeline.models.gnn.augmentations import drop_nodes, permute_edges
+from malware_pipeline.models.gnn.augmentations import AugmentationApplier
 from malware_pipeline.loss import FocalLoss
 
 
@@ -73,7 +73,15 @@ def run(cfg: DictConfig) -> None:
     )
 
     # 3-2. 모델, 손실, 옵티마이저, 스케일러
-    gnn  = GraphCLEncoder(in_dim=dataset.in_dim, hidden_dim=256, out_dim=256).to(device)
+    aug_applier = AugmentationApplier(
+        cfg.model.augmentations, cfg.model.get("num_aug_strategies", 2)
+    )
+    gnn  = GraphCLEncoder(
+        in_dim=dataset.in_dim,
+        hidden_dim=256,
+        aug_configs=cfg.model.augmentations,
+        num_aug_strategies=cfg.model.get("num_aug_strategies", 2),
+    ).to(device)
     head = CapabilityHead(in_dim=256,         num_labels=dataset.num_labels).to(device)
 
     criterion = FocalLoss()
@@ -92,8 +100,8 @@ def run(cfg: DictConfig) -> None:
             y_multi = y_multi.to(device).float()
 
             # ── 데이터 증강 (view1, view2) ──────────────────────────────
-            view1 = [drop_nodes(d, cfg.training.aug_ratio)    for d in graphs.to_data_list()]
-            view2 = [permute_edges(d, cfg.training.aug_ratio) for d in graphs.to_data_list()]
+            view1 = [aug_applier.apply(d) for d in graphs.to_data_list()]
+            view2 = [aug_applier.apply(d) for d in graphs.to_data_list()]
             view1_batch = Batch.from_data_list(view1).to(device)
             view2_batch = Batch.from_data_list(view2).to(device)
 

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -3,7 +3,7 @@ import pytest
 torch = pytest.importorskip("torch")
 Data = pytest.importorskip("torch_geometric.data", minversion="0").Data
 
-from src.models.gnn.augmentations import drop_nodes, permute_edges
+from src.models.gnn.augmentations import drop_nodes, permute_edges, AugmentationApplier
 
 def test_drop_nodes_and_permute_edges():
     x = torch.randn(5, 4)
@@ -13,3 +13,15 @@ def test_drop_nodes_and_permute_edges():
     assert dropped.num_nodes <= data.num_nodes
     permuted = permute_edges(data, 0.4, add_same_number=False)
     assert permuted.edge_index.size(1) <= data.edge_index.size(1)
+
+
+def test_augmentation_applier_random_choice():
+    x = torch.randn(5, 4)
+    edge_index = torch.tensor([[0,1,2,3,4],[1,2,3,4,0]])
+    sample = Data(x=x, edge_index=edge_index)
+    applier = AugmentationApplier([
+        {"name": "drop_nodes", "p": 1.0},
+        {"name": "permute_edges", "p": 1.0},
+    ])
+    out = applier.apply(sample)
+    assert isinstance(out, Data)


### PR DESCRIPTION
## Summary
- introduce `configs/augmentations.yaml` for specifying augmentation strategies
- load augmentation defaults in main config and training pipeline
- implement `AugmentationApplier` for dynamic selection
- extend `GraphCLEncoder` to use configurable augmentations
- update training pipeline to apply random augmentations
- add unit test for augmentation applier

## Testing
- `pip install torch==2.5.1 torch_geometric==2.5.3 -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aacf70940832eb24e811fe5c436f8