### PR TITLE
Add Sphinx docs and docstring updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Build documentation
+        run: sphinx-build -b html docs docs/_build/html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_build/html
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/cli.py
+++ b/cli.py
@@ -58,9 +58,15 @@ def preprocess(
     radius: int = typer.Option(2, help="함수 서브그래프 추출 시 반경(k-hop)"),
     config_path: Path = typer.Option(None, "--config", help="파이프라인 설정 YAML 파일")
 ):
-    """Step 1: IR → function graphs.
+    """Convert IR files to function graphs.
 
-    생성된 그래프(`graphs/`)는 이후 ``train-gnn`` 단계에서 사용됩니다.
+    Args:
+        ir_dir (Path): Directory containing IR JSON files.
+        label_dir (Path): Directory with capability or metadata labels.
+        out_dir (Path): Destination directory for generated function graphs.
+        radius (int): Hop radius when extracting function subgraphs.
+        config_path (Path | None): Optional YAML configuration overriding
+            defaults.
     """
     if config_path and config_path.exists():
         cfg = Config.load(str(config_path))
@@ -82,7 +88,14 @@ def generate_cooc(
     output_path: Path = typer.Option(..., "--output", "-o", help="저장할 .npy 경로"),
     threshold: float = typer.Option(0.5, "--threshold", help="인접 행렬 이진화 임계값")
 ):
-    """라벨 공존 행렬(co-occurrence matrix)을 생성합니다."""
+    """Generate a label co-occurrence matrix.
+
+    Args:
+        label_file (Path): CSV file containing sample labels.
+        num_labels (int): Total number of unique labels.
+        output_path (Path): Output ``.npy`` path for the matrix.
+        threshold (float): Binarization threshold for matrix values.
+    """
     generate_cooccurrence_matrix(
         label_file=str(label_file),
         num_labels=num_labels,
@@ -96,10 +109,12 @@ def train_gnn(
     graphs_dir: Path = typer.Option(..., "--graphs", "-g", help="함수 그래프(.pt) 디렉터리"),
     model_out: Path = typer.Option(..., "--model-out", "-m", help="학습된 GNN 인코더 저장 디렉터리")
 ):
-    """Step 2: GraphCL encoder training.
+    """Train the GraphCL encoder on preprocessed graphs.
 
-    ``preprocess`` 단계에서 생성된 그래프를 입력으로 받아
-    임베딩(`embeds/`)을 생성합니다.
+    Args:
+        graphs_dir (Path): Directory with ``.pt`` graph files generated from
+            ``preprocess``.
+        model_out (Path): Directory to store the trained encoder parameters.
     """
     typer.echo("[INFO] Training GNN encoder (contrastive learning)...")
     orchestrator = Orchestrator(Config(data_dir=graphs_dir.parent, model_dir=model_out))
@@ -110,7 +125,12 @@ def train_gnn(
 def train_dummy(
     config_yaml: Path = typer.Option(..., "--config", "-c", help="Dummy detector 학습용 Hydra 설정 파일")
 ):
-    """더미 함수 vs 악성 함수 분류기를 학습시킵니다."""
+    """Train the dummy-function detector.
+
+    Args:
+        config_yaml (Path): Hydra configuration describing the training
+            parameters.
+    """
     typer.echo("[INFO] Training Dummy/Malicious classifier...")
     train_dummy_detector(config=str(config_yaml))
     typer.echo("[DONE] Dummy function detector training complete.")
@@ -121,9 +141,12 @@ def train_capability(
         Path("configs/config.yaml"), "--config", "-c", help="Hydra 설정 파일"
     )
 ):
-    """Step 3: Capability classifier training.
+    """Train the capability classifier using graph embeddings.
 
-    ``train-gnn`` 단계에서 생성된 임베딩을 입력으로 사용합니다.
+    Args:
+        config_yaml (Path): Path to the Hydra configuration file. The
+            configuration must define paths for embeddings and labels
+            generated from ``train-gnn``.
     """
     typer.echo("[INFO] Training CapabilityHead multi-label classifier...")
     orchestrator = Orchestrator(Config(data_dir=Path.cwd(), model_dir=Path.cwd()))
@@ -134,7 +157,12 @@ def train_capability(
 def train_desc(
     config_yaml: Path = typer.Option(..., "--config", "-c", help="설명 생성 학습용 Hydra 설정 파일")
 ):
-    """LoRA 기반 코드 설명 생성 모델을 학습시킵니다."""
+    """Train the LoRA-based code description model.
+
+    Args:
+        config_yaml (Path): Hydra configuration describing dataset paths and
+            training options for the description model.
+    """
     typer.echo("[INFO] Training LoRA description model...")
     from src.pipelines.desc_training import main as desc_main
     desc_main(config=str(config_yaml))
@@ -155,7 +183,22 @@ def train_rl(
     pref_batch: int = typer.Option(16, "--pref-batch", help="MORL: preference vector batch size"),
     env_config: Path = typer.Option(Path("configs/rl_env.yaml"), "--env-config", help="RL 환경 설정 YAML"),
 ):
-    """YARA 룰 생성을 위한 RL 에이전트를 학습시킵니다."""
+    """Train the reinforcement learning agent for YARA rule generation.
+
+    Args:
+        algo (str): RL algorithm to use (e.g., ``PPO`` or ``DQN``).
+        features_path (Path): Path to pre-extracted static features.
+        benign_db (Path): Directory with benign samples.
+        malicious_db (Path): Directory with malicious samples.
+        out_dir (Path): Where to store the trained agent.
+        timesteps (int): Number of training timesteps.
+        num_envs (int): Number of parallel environments.
+        seed (int): Random seed value.
+        reward_weights (str): Comma separated reward weight values.
+        use_morl (bool): Whether to use multi-objective reinforcement learning.
+        pref_batch (int): Preference vector batch size for MORL.
+        env_config (Path): Path to environment configuration YAML.
+    """
     typer.echo(f"[INFO] Training RL agent ({algo})...")
 
     # 문자열로 받은 가중치를 float 튜플로 변환
@@ -191,7 +234,13 @@ def describe_code(
     embed_path: Path = typer.Option(..., "--embed", "-e", help="그래프 임베딩(.pt)"),
     model_path: Path = typer.Option(..., "--model", "-m", help="LoRA 어댑터 경로"),
 ):
-    """학습된 LoRA 모델로 코드 설명을 생성합니다."""
+    """Generate a natural language description for the given code.
+
+    Args:
+        code_file (Path): Path to the source code file.
+        embed_path (Path): Path to a graph embedding of the code.
+        model_path (Path): Path to the trained LoRA adapter weights.
+    """
     from src.models.lora.lora_desc import LoRADescModel
 
     if not code_file.exists() or not embed_path.exists() or not model_path.exists():
@@ -212,8 +261,12 @@ def detect_function(
     model_path: Path = typer.Option(..., "--model", "-m", help="학습된 GNN 인코더 모델 파일 경로"),
     config_yaml: Path = typer.Option(Path("configs/config.yaml"), "--config", help="Hydra 설정 파일")
 ):
-    """
-    주어진 함수 바이너리로부터 그래프를 생성하고, 학습된 모델로 악성 여부를 탐지합니다.
+    """Detect malicious code from a function binary using a trained model.
+
+    Args:
+        input_path (Path): Path to the binary function file.
+        model_path (Path): Trained GNN encoder weights.
+        config_yaml (Path): Hydra configuration used for building graphs.
     """
     LOG.info("Starting detection for input: %s", input_path)
     LOG.info("Using model from: %s", model_path)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,16 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'Malware Pipeline'
+author = 'Malware Research Team'
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+html_theme = 'alabaster'
+
+# Paths
+templates_path = ['_templates']
+exclude_patterns = []
+
+# Napoleon settings for Google/Numpy style docstrings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,8 @@
+Malware Pipeline Documentation
+==============================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,12 @@
+API Reference
+=============
+
+.. automodule:: cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: src.pipelines.orchestrator
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 torch
 torch_geometric
 hydra-core
+sphinx

--- a/src/pipelines/orchestrator.py
+++ b/src/pipelines/orchestrator.py
@@ -32,13 +32,21 @@ LOG = logging.getLogger(__name__)
 
 
 class Orchestrator:
-    """
-    악성코드 분석 파이프라인을 조율합니다.
-    (torch_geometric HeteroData 버전)
+    """Coordinate the malware analysis pipeline.
+
+    The orchestrator ties together graph building, labeling and various
+    training stages. It operates on ``torch_geometric`` ``HeteroData`` objects
+    and exposes helper methods that are used by the CLI.
     """
 
     def __init__(self, config: Config, ir_dir: str | os.PathLike = "data/ir"):
-        """Initialize pipeline orchestrator."""
+        """Initialize the orchestrator.
+
+        Args:
+            config (Config): Parsed pipeline configuration object.
+            ir_dir (str | os.PathLike): Directory containing intermediate
+                representation JSON files. Defaults to ``"data/ir"``.
+        """
         self.config = config
         self.ir_dir = os.fspath(ir_dir)
         # GraphBuilder is responsible only for creating graphs
@@ -59,11 +67,20 @@ class Orchestrator:
         max_nodes: int = 5_000,
         bidirectional: bool = True,
     ) -> HeteroData:
-        """
-        • PyG `to_homogeneous` + `k_hop_subgraph` 사용으로 BFS 를 GPU-tensor
-          연산으로 처리 → 속도·메모리 ↑
-        • `max_nodes` 초과 시 앞쪽부터 잘라 폭주 방지.
-        • 결과가 비면 함수 노드 단독 그래프 반환.
+        """Extract a k-hop subgraph around a function node.
+
+        Args:
+            full_graph (HeteroData): Full program graph.
+            function_node_idx (int): Index of the target function node.
+            num_hops (int, optional): Radius for the subgraph. Defaults to ``10``.
+            max_nodes (int, optional): Hard cap on the number of nodes in the
+                resulting subgraph. Defaults to ``5000``.
+            bidirectional (bool, optional): If ``True``, edges are treated as
+                undirected when searching. Defaults to ``True``.
+
+        Returns:
+            HeteroData: Extracted subgraph. Falls back to a single node graph if
+            no neighbors are found.
         """
         if "function" not in full_graph.node_types:
             return HeteroData()
@@ -113,6 +130,12 @@ class Orchestrator:
     # 빈 서브그래프 스킵 대신 fallback 처리로 변경
     # -----------------------------------------------------------------
     def process(self, sample_ids: List[str]):
+        """Build and label graphs for a list of samples.
+
+        Args:
+            sample_ids (List[str]): List of sample identifiers. Each
+                identifier corresponds to an IR JSON file under ``ir_dir``.
+        """
         for sample_id in tqdm(sample_ids):
             LOG.info(f"Processing sample: {sample_id}")
             try:
@@ -162,11 +185,22 @@ class Orchestrator:
     # 학습 단계 호출을 위한 래퍼 메서드들
     # -----------------------------------------------------------------
     def train_gnn(self, graphs_dir: Path, model_out: Path) -> None:
-        """Run GraphCL encoder training on preprocessed graphs."""
+        """Run GraphCL encoder training on preprocessed graphs.
+
+        Args:
+            graphs_dir (Path): Directory containing ``.pt`` graph files.
+            model_out (Path): Directory where the trained encoder checkpoint will
+                be saved.
+        """
         train_hdhg(graphs_dir, model_out)
 
     def train_capability(self, config_yaml: Path) -> None:
-        """Train capability classifier using graph embeddings."""
+        """Train capability classifier using graph embeddings.
+
+        Args:
+            config_yaml (Path): Hydra style configuration for the capability
+                classifier.
+        """
         from hydra import compose, initialize
         from hydra.utils import to_absolute_path
 


### PR DESCRIPTION
## Summary
- create Sphinx configuration in `docs/`
- standardize docstrings for `cli.py` and `orchestrator.py`
- install `sphinx` via requirements
- add GitHub Actions workflow to build and deploy docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab5ab7094832e89c3b8d375e480c0