### PR TITLE
Improve LoRA description loader

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -233,6 +233,7 @@ def describe_code(
     code_file: Path = typer.Option(..., "--code", "-c", help="코드 파일 경로"),
     embed_path: Path = typer.Option(..., "--embed", "-e", help="그래프 임베딩(.pt)"),
     model_path: Path = typer.Option(..., "--model", "-m", help="LoRA 어댑터 경로"),
+    base_model: str = typer.Option(None, "--base-model", help="기반 모델 체크포인트"),
 ):
     """Generate a natural language description for the given code.
 
@@ -240,6 +241,7 @@ def describe_code(
         code_file (Path): Path to the source code file.
         embed_path (Path): Path to a graph embedding of the code.
         model_path (Path): Path to the trained LoRA adapter weights.
+        base_model (str | None): Optional HF model checkpoint.
     """
     from src.models.lora.lora_desc import LoRADescModel
 
@@ -249,8 +251,8 @@ def describe_code(
 
     code = code_file.read_text()
     vec = torch.load(embed_path)
-    model = LoRADescModel()
-    model.model.load_state_dict(torch.load(model_path))
+    model = LoRADescModel(base_model_name=base_model) if base_model else LoRADescModel()
+    model.load_adapter(model_path)
     typer.echo(model.generate_description(code, vec))
 
 

--- a/configs/lora_desc.yaml
+++ b/configs/lora_desc.yaml
@@ -4,6 +4,7 @@ use_longformer: true          # LED 사용
 use_adapter: true             # Houlsby 어댑터 활성
 cross_attention_prefix: true  # 그래프 prefix 토큰 주입
 prefix_len: 6                 # prefix 토큰 개수
+hedge_dim: 128                # HDHG 임베딩 차원
 # LoRA
 r: 16
 alpha: 32

--- a/src/models/lora/lora_desc.py
+++ b/src/models/lora/lora_desc.py
@@ -57,7 +57,7 @@ class LoRADescModel:
     # ------------------------------------------------------------------
     # 초기화
     # ------------------------------------------------------------------
-    def __init__(self, base_model_name: str = "EleutherAI/gpt-neo-125M"):
+    def __init__(self, base_model_name: str = "EleutherAI/gpt-neo-125M", hedge_dim: int = 128):
         # 1) 설정 파일 로드 -------------------------------------------------
         cfg_path = Path(__file__).resolve().parents[2] / "configs" / "lora_desc.yaml"
         cfg = yaml.safe_load(cfg_path.open()) if cfg_path.exists() else {}
@@ -67,6 +67,7 @@ class LoRADescModel:
         self.use_longform = bool(cfg.get("use_longformer", False))
         self.use_adapter  = bool(cfg.get("use_adapter", False))
         self.prefix_len   = int(cfg.get("prefix_len", 4))            # 교차 어텐션 prefix 토큰 수
+        self.hedge_dim    = int(cfg.get("hedge_dim", hedge_dim))
         self.cross_prefix = bool(cfg.get("cross_attention_prefix", True))
         self.device       = torch.device(cfg.get("device", "cpu"))
 
@@ -113,32 +114,40 @@ class LoRADescModel:
         self.model.resize_token_embeddings(len(self.tokenizer))
 
         # 6) Prefix-MLP(그래프 벡터 → 가상 토큰) ----------------------------
-        # hedge_vec_dim 은 런타임에 결정될 수 있으므로, 첫 호출 때 생성
-        self.prefix_project: Optional[nn.Linear] = None
+        hidden_size = self.model.config.hidden_size
+        self.prefix_project: nn.Linear = nn.Linear(
+            self.hedge_dim, self.prefix_len * hidden_size, bias=False
+        )
 
         self.model.to(self.device)
 
     # ------------------------------------------------------------------
+    # Load trained LoRA adapter weights
+    # ------------------------------------------------------------------
+    def load_adapter(self, adapter_path: str) -> None:
+        """Load LoRA adapter weights if available."""
+        if not Path(adapter_path).exists():
+            raise FileNotFoundError(adapter_path)
+        try:
+            from peft import PeftModel
+            self.model = PeftModel.from_pretrained(self.model, adapter_path)
+        except Exception:  # noqa: BLE001
+            state = torch.load(adapter_path, map_location=self.device)
+            self.model.load_state_dict(state)
+
+    # ------------------------------------------------------------------
     # 내부: 그래프 벡터 → prefix 임베딩
     # ------------------------------------------------------------------
-    def _build_prefix(
-        self, hedge_vec: torch.Tensor, hidden_size: int
-    ) -> torch.Tensor:
+    def _build_prefix(self, hedge_vec: torch.Tensor) -> torch.Tensor:
         """
         Args:
             hedge_vec : (h_dim,) or (1, h_dim)
         Returns:
             prefix_embeds : (1, prefix_len, hidden_size)
         """
-        if self.prefix_project is None:
-            in_dim = hedge_vec.size(-1)
-            self.prefix_project = nn.Linear(
-                in_dim, self.prefix_len * hidden_size, bias=False
-            ).to(self.device)
-
         vec = hedge_vec.to(self.device).unsqueeze(0)  # (1, h_dim)
         out = self.prefix_project(vec)                # (1, prefix_len*hidden)
-        return out.view(1, self.prefix_len, hidden_size)
+        return out.view(1, self.prefix_len, self.model.config.hidden_size)
 
     # ------------------------------------------------------------------
     # 설명 생성
@@ -165,8 +174,7 @@ class LoRADescModel:
 
         # ---- 교차 어텐션 prefix 주입 --------------------------------------
         if self.cross_prefix:
-            hidden_size = self.model.config.hidden_size
-            prefix_emb = self._build_prefix(hedge_vec, hidden_size)  # (1,prefix_len,hid)
+            prefix_emb = self._build_prefix(hedge_vec)  # (1,prefix_len,hid)
             # ① 기존 토큰 임베딩
             tok_emb = self.model.get_input_embeddings()(input_ids)
             # ② 연결

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,3 +15,36 @@ def test_detect_invalid_input(tmp_path: Path):
     result = runner.invoke(app, ["detect-function", "--input", str(tmp_path/"no.bin"), "--model", str(model)])
     assert result.exit_code != 0
     assert "input file not found" in result.stdout.lower()
+
+
+def test_describe_code_smoke(tmp_path: Path):
+    torch = pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    from src.models.lora.lora_desc import LoRADescModel
+
+    code_f = tmp_path / "sample.py"
+    code_f.write_text("def foo(x):\n    return x + 1")
+    vec_f = tmp_path / "vec.pt"
+    torch.save(torch.randn(128), vec_f)
+
+    model = LoRADescModel(base_model_name="sshleifer/tiny-gpt2")
+    adapter_f = tmp_path / "adapter.bin"
+    torch.save(model.model.state_dict(), adapter_f)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "describe-code",
+            "--code",
+            str(code_f),
+            "--embed",
+            str(vec_f),
+            "--model",
+            str(adapter_f),
+            "--base-model",
+            "sshleifer/tiny-gpt2",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip()


### PR DESCRIPTION
## Summary
- update `lora_desc.yaml` with hedge_dim
- define prefix MLP at initialization and add adapter loader
- allow `describe-code` CLI to specify base model
- add smoke test for `describe-code`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac97ae078832e9a16c4e48279dd7c