### PR TITLE
Fix RL reward weight dimensions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -178,7 +178,7 @@ def train_rl(
     timesteps: int = typer.Option(2_000_000, "--timesteps", help="학습 총 타임스텝"),
     num_envs: int = typer.Option(4, "--envs", help="병렬 환경 수"),
     seed: int = typer.Option(42, "--seed", help="랜덤 시드"),
-    reward_weights: Annotated[str, typer.Option("--reward-weights", help="보상 가중치 예: '1.0,0.2,0.5'")] = "1.0,0.2,0.5",
+    reward_weights: Annotated[str, typer.Option("--reward-weights", help="보상 가중치 예: '1.0,1.0,1.0,1.0,1.0,1.0'")] = "1.0,1.0,1.0,1.0,1.0,1.0",
     use_morl: bool = typer.Option(False, "--morl", help="다목적 RL(MORL-Baselines) 사용"),
     pref_batch: int = typer.Option(16, "--pref-batch", help="MORL: preference vector batch size"),
     env_config: Path = typer.Option(Path("configs/rl_env.yaml"), "--env-config", help="RL 환경 설정 YAML"),
@@ -194,7 +194,7 @@ def train_rl(
         timesteps (int): Number of training timesteps.
         num_envs (int): Number of parallel environments.
         seed (int): Random seed value.
-        reward_weights (str): Comma separated reward weight values.
+        reward_weights (str): Comma separated reward weight values (6 numbers).
         use_morl (bool): Whether to use multi-objective reinforcement learning.
         pref_batch (int): Preference vector batch size for MORL.
         env_config (Path): Path to environment configuration YAML.
@@ -204,10 +204,13 @@ def train_rl(
     # 문자열로 받은 가중치를 float 튜플로 변환
     try:
         weights = tuple(map(float, reward_weights.split(',')))
-        if len(weights) != 3:
+        if len(weights) != 6:
             raise ValueError
     except (ValueError, AttributeError):
-        typer.echo(f"Error: Invalid format for --reward-weights. Please use 'w1,w2,w3'.", err=True)
+        typer.echo(
+            "Error: Invalid format for --reward-weights. Please use 'w1,w2,w3,w4,w5,w6'.",
+            err=True,
+        )
         raise typer.Exit(code=1)
 
     # 학습 스크립트 호출 - 인자 형식 및 개수를 검증하여 전달

--- a/src/pipelines/train_rl_agent.py
+++ b/src/pipelines/train_rl_agent.py
@@ -210,7 +210,7 @@ def train(
     total_steps: int,
     num_envs: int,
     seed: int | None,
-    reward_weights: Tuple[float, float, float],
+    reward_weights: Tuple[float, float, float, float, float, float],
     out_root: Path,
     pref_batch: int,
     env_config: Path,
@@ -278,9 +278,21 @@ def cli() -> None:
     ap.add_argument("--steps", default=2_000_000, type=int)
     ap.add_argument("--envs", default=4, type=int, help="parallel envs")
     ap.add_argument("--seed", default=42, type=int)
-    ap.add_argument("--weights", nargs=3, default=(1.0, 0.2, 0.5), type=float,
-                    metavar=("W_DETECT", "W_CONCISE", "W_IMPORT"),
-                    help="scalarization weights (SB3 모드)")
+    ap.add_argument(
+        "--weights",
+        nargs=6,
+        default=(1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+        type=float,
+        metavar=(
+            "W_DETECT",
+            "W_CONCISE",
+            "W_FAMILY",
+            "W_DUP",
+            "W_COMPLEX",
+            "W_DIVERSE",
+        ),
+        help="scalarization weights (SB3 모드)",
+    )
     ap.add_argument("--morl", action="store_true", help="다목적 RL 사용")
     ap.add_argument("--pref-batch", default=16, type=int,
                     help="PCPG/PCN : preference batch size")


### PR DESCRIPTION
## Summary
- update CLI to expect six reward weights for RL agent training
- adjust parsing and validation for new weight length
- update SB3 training script to accept 6D scalarization weights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad1b52e4c832e988f101b500ae14a