### PR TITLE
Improve pipeline error handling

### DIFF
--- a/web/pipeline_wrapper.py
+++ b/web/pipeline_wrapper.py
@@ -1,47 +1,56 @@
 # web/pipeline_wrapper.py
 
 import os
+import subprocess
 from src.pipelines.orchestrator import Orchestrator
 
 
+class UnsupportedFileTypeError(Exception):
+    """Raised when the uploaded file is not a supported PE file."""
+
+
+class AnalysisTimeoutError(Exception):
+    """Raised when an external analysis step takes too long."""
+
+
+def emit_log(socketio, message: str, error: bool = False):
+    """Helper to send log messages to the client."""
+    socketio.emit("new_log", {"msg": message, "error": error})
+
+
 def run_analysis_pipeline(socketio, sample_path):
-    """
-    분석 파이프라인을 실행하고 진행 상황을 클라이언트로 전송합니다.
+    """Run the analysis pipeline and stream progress logs to the client."""
 
-    :param socketio: Flask-SocketIO 인스턴스
-    :param sample_path: 분석할 파일 경로
-    """
     try:
-        # 1. 상태 업데이트: 전처리 시작
-        socketio.emit('status_update', {'msg': '분석 시작: 전처리 단계를 시작합니다...'})
+        emit_log(socketio, "전처리 시작...")
+        if not sample_path.endswith((".exe", ".dll")):
+            raise UnsupportedFileTypeError("지원하지 않는 파일 형식입니다. PE 파일만 분석 가능합니다.")
 
-        # 실제 Orchestrator의 전처리 메소드 호출 (예시)
         # orchestrator = Orchestrator(...)
         # preprocessed_data = orchestrator.preprocess(sample_path)
-        socketio.sleep(2)  # 실제 작업 시뮬레이션
+        socketio.sleep(2)
 
-        # 2. 상태 업데이트: GNN 모델 분석
-        socketio.emit('status_update', {'msg': 'GNN 모델을 사용하여 분석 중입니다...'})
+        emit_log(socketio, "GNN 분석 시작...")
         # gnn_results = orchestrator.analyze_with_gnn(preprocessed_data)
         socketio.sleep(3)
 
-        # 3. 상태 업데이트: YARA 룰 탐지
-        socketio.emit('status_update', {'msg': 'YARA 룰 기반 탐지를 수행합니다...'})
+        emit_log(socketio, "YARA 룰 기반 탐지를 수행합니다...")
         # yara_results = orchestrator.detect_with_yara(sample_path)
         socketio.sleep(2)
 
-        # 4. 상태 업데이트: 보고서 생성
-        socketio.emit('status_update', {'msg': '분석 완료: 보고서를 생성 중입니다...'})
+        emit_log(socketio, "분석 완료: 보고서를 생성 중입니다...")
         # report = orchestrator.generate_report(gnn_results, yara_results)
         socketio.sleep(1)
 
-        # 5. 분석 완료 이벤트 전송
         sample_id = os.path.basename(sample_path)
-        # 생성된 보고서의 ID 또는 식별자를 전달
-        socketio.emit('analysis_complete', {'report_id': sample_id})
+        socketio.emit("analysis_complete", {"report_id": sample_id})
 
+    except UnsupportedFileTypeError as e:
+        emit_log(socketio, f"오류 발생: {e}", error=True)
+    except subprocess.TimeoutExpired:
+        emit_log(socketio, "오류 발생: 분석 시간이 초과되었습니다.", error=True)
     except Exception as e:
-        socketio.emit('status_error', {'msg': f'오류 발생: {str(e)}'})
+        emit_log(socketio, f"알 수 없는 오류 발생: {str(e)}", error=True)
 
 
 def run_pipeline(sample_path: str):
@@ -61,12 +70,8 @@ def run_pipeline(sample_path: str):
         "detected_rules": ["Suspicious_EXE", "Packed_UPX"],
         "capabilities": ["network_communication", "file_creation"],
         "visualization": {
-            "capabilities": {
-                "labels": ["Stealer", "Downloader", "C&C", "Keylogger"],
-                "values": [8, 5, 7, 3]
-            }
-        }
+            "capabilities": {"labels": ["Stealer", "Downloader", "C&C", "Keylogger"], "values": [8, 5, 7, 3]}
+        },
     }
 
     return report_data
-

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -43,6 +43,17 @@ document.addEventListener('DOMContentLoaded', () => {
         addStatusLog(data.msg);
     });
 
+    socket.on('new_log', function(data) {
+        const logEntry = document.createElement('p');
+        logEntry.textContent = data.msg;
+        if (data.error) {
+            logEntry.style.color = 'red';
+            logEntry.style.fontWeight = 'bold';
+        }
+        statusLog.appendChild(logEntry);
+        statusLog.scrollTop = statusLog.scrollHeight;
+    });
+
     // 'analysis_complete' 이벤트 수신
     socket.on('analysis_complete', (data) => {
         addStatusLog('분석 완료! 결과 페이지로 이동합니다.', 'success');


### PR DESCRIPTION
## Summary
- add custom exceptions and per-step error handling in `pipeline_wrapper.py`
- stream logs via `new_log` SocketIO event
- highlight error logs in frontend using `main.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeb39c7e8832eb947efe89dc6c840