### PR TITLE
Add analysis history database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ hydra-core
 sphinx
 scikit-learn
 weasyprint
+
+Flask
+Flask-SocketIO
+Flask-SQLAlchemy

--- a/web/app.py
+++ b/web/app.py
@@ -1,10 +1,13 @@
 # web/app.py
 
 import os
+import json
+import datetime
 from flask import Flask, render_template, request, send_from_directory, jsonify
 from flask_socketio import SocketIO
 from werkzeug.utils import secure_filename
 from weasyprint import HTML
+from flask_sqlalchemy import SQLAlchemy
 
 # 직접 작성한 파이프라인 래퍼 임포트
 from pipeline_wrapper import run_analysis_pipeline, run_pipeline
@@ -13,6 +16,31 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = 'your-secret-key'
 app.config['UPLOAD_FOLDER'] = 'uploads/'  # 업로드된 파일이 저장될 임시 폴더
 socketio = SocketIO(app, async_mode='eventlet')
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///malware_analysis.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+db = SQLAlchemy(app)
+
+
+class Analysis(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(100), nullable=False)
+    upload_time = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+    status = db.Column(db.String(20), default='pending')
+    report_json = db.Column(db.Text, nullable=True)
+
+
+with app.app_context():
+    db.create_all()
+
+
+def update_analysis_result(analysis_id, status, report_data):
+    """Update the analysis record once processing is finished."""
+    with app.app_context():
+        analysis = Analysis.query.get(analysis_id)
+        if analysis:
+            analysis.status = status
+            analysis.report_json = json.dumps(report_data)
+            db.session.commit()
 
 # 업로드 폴더 생성
 os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
@@ -22,6 +50,13 @@ os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
 def index():
     """메인 페이지 렌더링"""
     return render_template('index.html')
+
+
+@app.route('/history')
+def history():
+    """Show list of past analyses."""
+    analyses = Analysis.query.order_by(Analysis.upload_time.desc()).all()
+    return render_template('history.html', analyses=analyses)
 
 
 @socketio.on('connect')
@@ -39,8 +74,13 @@ def handle_start_analysis(json):
 
     sample_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
 
+    # 새 분석 기록 생성
+    new_analysis = Analysis(filename=filename, status='processing')
+    db.session.add(new_analysis)
+    db.session.commit()
+
     # 백그라운드에서 파이프라인 실행
-    socketio.start_background_task(run_analysis_pipeline, socketio, sample_path)
+    socketio.start_background_task(run_analysis_pipeline, socketio, sample_path, new_analysis.id)
 
 
 @app.route('/upload', methods=['POST'])
@@ -58,23 +98,24 @@ def upload_file():
         return jsonify({"success": True, "filename": filename})
 
 
-@app.route('/report/<report_id>')
-def view_report(report_id):
+@app.route('/report/<int:analysis_id>')
+def view_report(analysis_id):
     """분석 결과 보고서 페이지 렌더링"""
-    # In a real deployment this would load stored JSON results. Here we
-    # generate a stub report using ``run_pipeline`` for demonstration.
-    sample_path = os.path.join(app.config['UPLOAD_FOLDER'], report_id)
-    report_data = run_pipeline(sample_path)
+    analysis = Analysis.query.get_or_404(analysis_id)
+    report_data = {}
+    if analysis.report_json:
+        report_data = json.loads(analysis.report_json)
 
     return render_template('report.html', report=report_data)
 
 
-@app.route('/report/pdf/<report_id>')
-def download_pdf_report(report_id):
+@app.route('/report/pdf/<int:analysis_id>')
+def download_pdf_report(analysis_id):
     """보고서 페이지를 PDF로 변환하여 다운로드"""
-    # Generate or load the same data shown in the HTML report
-    sample_path = os.path.join(app.config['UPLOAD_FOLDER'], report_id)
-    report_data = run_pipeline(sample_path)
+    analysis = Analysis.query.get_or_404(analysis_id)
+    report_data = {}
+    if analysis.report_json:
+        report_data = json.loads(analysis.report_json)
     html_string = render_template('report.html', report=report_data)
 
     # WeasyPrint를 사용하여 HTML을 PDF로 변환
@@ -82,7 +123,7 @@ def download_pdf_report(report_id):
 
     return pdf, 200, {
         'Content-Type': 'application/pdf',
-        'Content-Disposition': f'attachment; filename="{report_id}_report.pdf"'
+        'Content-Disposition': f'attachment; filename="{analysis_id}_report.pdf"'
     }
 
 

--- a/web/pipeline_wrapper.py
+++ b/web/pipeline_wrapper.py
@@ -18,8 +18,18 @@ def emit_log(socketio, message: str, error: bool = False):
     socketio.emit("new_log", {"msg": message, "error": error})
 
 
-def run_analysis_pipeline(socketio, sample_path):
-    """Run the analysis pipeline and stream progress logs to the client."""
+def run_analysis_pipeline(socketio, sample_path, analysis_id=None):
+    """Run the analysis pipeline and stream progress logs to the client.
+
+    Parameters
+    ----------
+    socketio : SocketIO
+        SocketIO instance for emitting events.
+    sample_path : str
+        Path to the uploaded sample.
+    analysis_id : int | None
+        Optional database ID to update when processing is finished.
+    """
 
     try:
         emit_log(socketio, "전처리 시작...")
@@ -42,15 +52,29 @@ def run_analysis_pipeline(socketio, sample_path):
         # report = orchestrator.generate_report(gnn_results, yara_results)
         socketio.sleep(1)
 
-        sample_id = os.path.basename(sample_path)
-        socketio.emit("analysis_complete", {"report_id": sample_id})
+        report = run_pipeline(sample_path)
+
+        if analysis_id is not None:
+            from app import update_analysis_result
+            update_analysis_result(analysis_id, "completed", report)
+
+        socketio.emit("analysis_complete", {"report_id": analysis_id or os.path.basename(sample_path)})
 
     except UnsupportedFileTypeError as e:
         emit_log(socketio, f"오류 발생: {e}", error=True)
+        if analysis_id is not None:
+            from app import update_analysis_result
+            update_analysis_result(analysis_id, "error", {})
     except subprocess.TimeoutExpired:
         emit_log(socketio, "오류 발생: 분석 시간이 초과되었습니다.", error=True)
+        if analysis_id is not None:
+            from app import update_analysis_result
+            update_analysis_result(analysis_id, "error", {})
     except Exception as e:
         emit_log(socketio, f"알 수 없는 오류 발생: {str(e)}", error=True)
+        if analysis_id is not None:
+            from app import update_analysis_result
+            update_analysis_result(analysis_id, "error", {})
 
 
 def run_pipeline(sample_path: str):

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>분석 이력</title>
+</head>
+<body>
+    <h1>분석 이력</h1>
+    <table border="1">
+        <tr>
+            <th>파일명</th>
+            <th>업로드 시간</th>
+            <th>상태</th>
+            <th>보고서</th>
+        </tr>
+        {% for analysis in analyses %}
+        <tr>
+            <td>{{ analysis.filename }}</td>
+            <td>{{ analysis.upload_time }}</td>
+            <td>{{ analysis.status }}</td>
+            <td>
+                {% if analysis.status == 'completed' %}
+                <a href="/report/{{ analysis.id }}">결과 보기</a>
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
     <h1>악성코드 분석 파이프라인</h1>
+    <a href="/history">분석 이력 보기</a>
     <input type="file" id="fileInput">
     <button id="uploadButton">분석 시작</button>
     <hr>


### PR DESCRIPTION
## Summary
- integrate SQLite database using Flask-SQLAlchemy
- track analysis jobs and allow report retrieval
- create history page listing completed analyses
- update pipeline wrapper to save results into DB
- expose history link in index page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aec249f5c832e99ef849569cc596a