### PR TITLE
Add progress updates via SocketIO

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Callable
 
 
 @dataclass
@@ -26,15 +27,35 @@ class AnalysisResult:
 class Orchestrator:
     """Dummy orchestrator for demonstration purposes."""
 
-    def run(self, file_path: str) -> AnalysisResult:
-        """Analyse the given file and return an ``AnalysisResult``.
+    def run(
+        self, file_path: str, progress_callback: Callable[[str, int], None] | None = None
+    ) -> AnalysisResult:
+        """Analyse ``file_path`` and optionally report progress.
 
-        This placeholder implementation simply checks the file name and
-        returns a fabricated result. In a real deployment this would run
-        the full malware analysis pipeline.
+        Parameters
+        ----------
+        file_path:
+            Path to the file to analyse.
+        progress_callback:
+            Optional ``callable`` receiving ``(stage: str, pct: int)`` to
+            report pipeline progress. When ``None`` a no-op callback is used.
         """
+
+        report_progress = progress_callback if progress_callback else lambda stage, pct: None
+
+        report_progress("프로세스 초기화", 10)
+
+        # 1. Feature extraction (dummy)
         base = os.path.basename(file_path)
         suspicious = "mal" in base.lower()
+        report_progress("특징 추출 완료", 40)
+
+        # 2. Graph creation (dummy)
+        report_progress("그래프 생성 완료", 70)
+
+        # 3. Inference (dummy)
         confidence = 0.9 if suspicious else 0.1
         details = {"filename": base}
+        report_progress("분석 완료", 100)
+
         return AnalysisResult(is_malicious=suspicious, confidence=confidence, details=details)

--- a/web/pipeline_wrapper.py
+++ b/web/pipeline_wrapper.py
@@ -37,9 +37,15 @@ def run_analysis_pipeline(file_path: str, sid: str) -> None:
         raise RuntimeError("SocketIO not initialised")
 
     print(f"[{sid}] 분석 시작: {os.path.basename(file_path)}")
+
+    def report_progress_to_client(stage: str, pct: int) -> None:
+        """Send progress updates to the connected client."""
+        print(f"[{sid}] 진행 상황: {stage} ({pct}%)")
+        socketio.emit("progress_update", {"stage": stage, "progress": pct}, room=sid)
+
     try:
         orchestrator = Orchestrator()
-        result = orchestrator.run(file_path)
+        result = orchestrator.run(file_path, progress_callback=report_progress_to_client)
         print(f"[{sid}] 분석 완료. 결과 전송.")
         socketio.emit("analysis_result", result.to_json(), room=sid)
     except Exception as e:  # pragma: no cover - runtime logging

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -63,6 +63,16 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('results').textContent = '오류 발생: ' + data.error;
     });
 
+    // pipeline progress updates
+    socket.on('progress_update', function(data) {
+        console.log('진행 상황:', data.stage, data.progress);
+        const bar = document.querySelector('.progress-bar');
+        if (bar) {
+            bar.style.width = data.progress + '%';
+            bar.textContent = data.stage;
+        }
+    });
+
     // 'status_error' 이벤트 수신
     socket.on('status_error', (data) => {
         addStatusLog(data.msg, 'error');


### PR DESCRIPTION
## Summary
- support progress reporting in the orchestrator
- propagate updates to the client in `pipeline_wrapper`
- update the front-end JS to handle `progress_update` events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af002cb5c832e8510933cc1df1b41