### PR TITLE
Add Cytoscape visualization for analysis graphs

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Any, List
 
 
 @dataclass
@@ -14,6 +14,22 @@ class AnalysisResult:
     is_malicious: bool
     confidence: float
     details: dict
+    graph: Any | None = None
+
+    def to_cytoscape_json(self) -> dict | None:
+        """Convert internal graph to Cytoscape.js elements structure."""
+        if self.graph is None:
+            return None
+
+        nodes = [
+            {"data": {"id": n["id"], "label": n.get("label", n["id"])}}
+            for n in getattr(self.graph, "nodes", [])
+        ]
+        edges = [
+            {"data": {"source": e["source"], "target": e["target"]}}
+            for e in getattr(self.graph, "edges", [])
+        ]
+        return {"nodes": nodes, "edges": edges}
 
     def to_json(self) -> dict:
         """Return a JSON serialisable dictionary."""
@@ -21,6 +37,7 @@ class AnalysisResult:
             "is_malicious": self.is_malicious,
             "confidence": self.confidence,
             "details": self.details,
+            "graph_data": self.to_cytoscape_json(),
         }
 
 
@@ -51,6 +68,15 @@ class Orchestrator:
         report_progress("특징 추출 완료", 40)
 
         # 2. Graph creation (dummy)
+        graph = {
+            "nodes": [
+                {"id": "start", "label": "Start"},
+                {"id": "end", "label": "End"},
+            ],
+            "edges": [
+                {"source": "start", "target": "end"},
+            ],
+        }
         report_progress("그래프 생성 완료", 70)
 
         # 3. Inference (dummy)
@@ -58,4 +84,10 @@ class Orchestrator:
         details = {"filename": base}
         report_progress("분석 완료", 100)
 
-        return AnalysisResult(is_malicious=suspicious, confidence=confidence, details=details)
+        return AnalysisResult(
+            is_malicious=suspicious,
+            confidence=confidence,
+            details=details,
+            graph=graph,
+        )
+

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -56,6 +56,24 @@ document.addEventListener('DOMContentLoaded', () => {
     socket.on('analysis_result', function(data) {
         console.log('분석 결과:', data);
         document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+
+        if (data.graph_data) {
+            cytoscape({
+                container: document.getElementById('cy'),
+                elements: data.graph_data,
+                style: [
+                    {
+                        selector: 'node',
+                        style: { 'label': 'data(label)' }
+                    },
+                    {
+                        selector: 'edge',
+                        style: { 'width': 2, 'line-color': '#ccc', 'target-arrow-color': '#ccc' }
+                    }
+                ],
+                layout: { name: 'cose' }
+            });
+        }
     });
 
     socket.on('analysis_error', function(data) {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3,6 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <title>Malware Pipeline</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"></script>
+    <style>
+        #cy {
+            width: 100%;
+            height: 500px;
+            border: 1px solid #ccc;
+            margin-top: 1rem;
+        }
+    </style>
 </head>
 <body>
     <h1>악성코드 분석 파이프라인</h1>
@@ -13,6 +22,7 @@
     <h2>분석 상태</h2>
     <ul id="statusLog"></ul>
     <pre id="results"></pre>
+    <div id="cy"></div>
 
     <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
     <script src="/static/js/main.js"></script>


### PR DESCRIPTION
## Summary
- add optional graph field to `AnalysisResult`
- expose HDHG graph data in Cytoscape.js format
- embed Cytoscape viewer in the web UI
- render graph with Cytoscape when analysis completes

## Testing
- `pip install -r requirements.txt typer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af0aea39c832e93d6a6607424088f