### PR TITLE
Enable async analysis via Celery and Redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ weasyprint
 Flask
 Flask-SocketIO
 Flask-SQLAlchemy
+celery[redis]

--- a/web/app.py
+++ b/web/app.py
@@ -4,13 +4,14 @@ import os
 import json
 import datetime
 from flask import Flask, render_template, request, send_from_directory, jsonify
+# SocketIO is kept for potential future use, but not required for results push
 from flask_socketio import SocketIO
 from werkzeug.utils import secure_filename
 from weasyprint import HTML
 from flask_sqlalchemy import SQLAlchemy
 
-# 직접 작성한 파이프라인 래퍼 임포트
-from . import pipeline_wrapper
+# Celery task import
+from .tasks import run_analysis_task
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'your-secret-key'
@@ -20,8 +21,8 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///malware_analysis.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
-# SocketIO instance to pipeline wrapper
-pipeline_wrapper.set_socketio(socketio)
+# SocketIO instance setup (not used for results push)
+# pipeline_wrapper.set_socketio(socketio)
 
 
 class Analysis(db.Model):
@@ -62,10 +63,10 @@ def history():
     return render_template('history.html', analyses=analyses)
 
 
-@socketio.on('connect')
-def handle_connect():
-    """클라이언트 연결 시 호출"""
-    print('Client connected')
+# @socketio.on('connect')
+# def handle_connect():
+#     """클라이언트 연결 시 호출"""
+#     print('Client connected')
 
 
 
@@ -83,12 +84,22 @@ def upload_file():
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(filepath)
 
-        # Start analysis in background for this client's session
-        socketio.start_background_task(
-            pipeline_wrapper.run_analysis_pipeline, filepath, request.sid
-        )
+        # Run analysis via Celery in the background
+        task = run_analysis_task.delay(filepath)
 
-        return jsonify({"success": True, "message": "분석이 시작되었습니다."})
+        # Return task id for polling
+        return jsonify({'success': True, 'task_id': task.id})
+
+
+@app.route('/task_status/<task_id>', methods=['GET'])
+def get_task_status(task_id):
+    """Return Celery task state and metadata."""
+    task = run_analysis_task.AsyncResult(task_id)
+    response = {
+        'state': task.state,
+        'meta': task.info,
+    }
+    return jsonify(response)
 
 
 @app.route('/report/<int:analysis_id>')
@@ -121,4 +132,4 @@ def download_pdf_report(analysis_id):
 
 
 if __name__ == '__main__':
-    socketio.run(app, debug=True)
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1,109 +1,74 @@
-// web/static/js/main.js
+$(document).ready(function() {
+    $('#upload-form').on('submit', function(e) {
+        e.preventDefault();
+        var formData = new FormData(this);
 
-document.addEventListener('DOMContentLoaded', () => {
-    const socket = io(); // Flask 서버에 Socket.IO 연결
+        // 초기화 및 로딩 표시
+        $('#results').empty();
+        $('#graph-container').empty();
+        $('.progress').show();
 
-    const fileInput = document.getElementById('fileInput');
-    const uploadButton = document.getElementById('uploadButton');
-    const statusLog = document.getElementById('statusLog');
-
-    // 분석 시작 버튼 클릭 이벤트
-    uploadButton.addEventListener('click', () => {
-        const file = fileInput.files[0];
-        if (!file) {
-            alert('분석할 파일을 선택하세요.');
-            return;
-        }
-
-        statusLog.innerHTML = ''; // 이전 로그 초기화
-        const formData = new FormData();
-        formData.append('file', file);
-
-        // 1. 파일을 서버에 업로드
-        fetch('/upload', {
-            method: 'POST',
-            body: formData
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                addStatusLog(data.message, 'success');
-            } else {
-                addStatusLog(`파일 업로드 실패: ${data.error}`, 'error');
+        $.ajax({
+            url: '/upload',
+            type: 'POST',
+            data: formData,
+            processData: false,
+            contentType: false,
+            success: function(data) {
+                if (data.success) {
+                    pollTaskStatus(data.task_id);
+                }
+            },
+            error: function() {
+                alert('파일 업로드에 실패했습니다.');
             }
-        })
-        .catch(error => {
-            addStatusLog(`오류 발생: ${error}`, 'error');
         });
     });
-
-    // 'status_update' 이벤트 수신
-    socket.on('status_update', (data) => {
-        addStatusLog(data.msg);
-    });
-
-    socket.on('new_log', function(data) {
-        const logEntry = document.createElement('p');
-        logEntry.textContent = data.msg;
-        if (data.error) {
-            logEntry.style.color = 'red';
-            logEntry.style.fontWeight = 'bold';
-        }
-        statusLog.appendChild(logEntry);
-        statusLog.scrollTop = statusLog.scrollHeight;
-    });
-
-    socket.on('analysis_result', function(data) {
-        console.log('분석 결과:', data);
-        document.getElementById('results').textContent = JSON.stringify(data, null, 2);
-
-        if (data.graph_data) {
-            cytoscape({
-                container: document.getElementById('cy'),
-                elements: data.graph_data,
-                style: [
-                    {
-                        selector: 'node',
-                        style: { 'label': 'data(label)' }
-                    },
-                    {
-                        selector: 'edge',
-                        style: { 'width': 2, 'line-color': '#ccc', 'target-arrow-color': '#ccc' }
-                    }
-                ],
-                layout: { name: 'cose' }
-            });
-        }
-    });
-
-    socket.on('analysis_error', function(data) {
-        console.error('분석 오류:', data.error);
-        document.getElementById('results').textContent = '오류 발생: ' + data.error;
-    });
-
-    // pipeline progress updates
-    socket.on('progress_update', function(data) {
-        console.log('진행 상황:', data.stage, data.progress);
-        const bar = document.querySelector('.progress-bar');
-        if (bar) {
-            bar.style.width = data.progress + '%';
-            bar.textContent = data.stage;
-        }
-    });
-
-    // 'status_error' 이벤트 수신
-    socket.on('status_error', (data) => {
-        addStatusLog(data.msg, 'error');
-    });
-
-    function addStatusLog(message, type = 'info') {
-        const li = document.createElement('li');
-        li.textContent = message;
-        if (type === 'error') {
-            li.style.color = 'red';
-        } else if (type === 'success') {
-            li.style.color = 'green';
-        }
-        statusLog.appendChild(li);
-    }
 });
+
+function pollTaskStatus(taskId) {
+    var interval = setInterval(function() {
+        $.ajax({
+            url: '/task_status/' + taskId,
+            type: 'GET',
+            success: function(data) {
+                if (data.state === 'PROGRESS') {
+                    $('.progress-bar').css('width', data.meta.progress + '%').text(data.meta.stage);
+                } else if (data.state === 'SUCCESS') {
+                    clearInterval(interval);
+                    $('.progress-bar').css('width', '100%').text('완료');
+                    displayResults(data.meta.result);
+                } else if (data.state === 'FAILURE') {
+                    clearInterval(interval);
+                    $('.progress-bar').addClass('bg-danger').text('오류 발생');
+                    $('#results').text('분석 오류: ' + data.meta.error);
+                }
+            },
+            error: function() {
+                clearInterval(interval);
+                alert('작업 상태를 가져오는 데 실패했습니다.');
+            }
+        });
+    }, 2000);
+}
+
+function displayResults(result) {
+    var resultText = `
+        <p><strong>악성 여부:</strong> ${result.is_malicious}</p>
+        <p><strong>신뢰도:</strong> ${result.confidence}</p>
+        <p><strong>상세:</strong> <pre>${JSON.stringify(result.details, null, 2)}</pre></p>
+    `;
+    $('#results').html(resultText);
+
+    if (result.graph_data) {
+        cytoscape({
+            container: document.getElementById('graph-container'),
+            elements: result.graph_data,
+            style: [
+                { selector: 'node', style: { 'label': 'data(label)' } },
+                { selector: 'edge', style: { 'width': 2, 'line-color': '#ccc', 'target-arrow-color': '#ccc' } }
+            ],
+            layout: { name: 'cose' }
+        });
+    }
+}

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -1,0 +1,35 @@
+import os
+from celery import Celery
+from src.orchestrator import Orchestrator
+
+celery_app = Celery(
+    'web.tasks',
+    broker='redis://localhost:6379/0',
+    backend='redis://localhost:6379/1'
+)
+
+@celery_app.task(bind=True)
+def run_analysis_task(self, file_path: str):
+    """Run analysis in a Celery worker."""
+    orchestrator = Orchestrator()
+
+    def report_progress(stage: str, pct: int) -> None:
+        self.update_state(state='PROGRESS', meta={'stage': stage, 'progress': pct})
+
+    try:
+        print(f"[Celery Task {self.request.id}] 분석 시작: {os.path.basename(file_path)}")
+        report_progress('분석 시작', 0)
+        result = orchestrator.run(file_path, progress_callback=report_progress)
+        print(f"[Celery Task {self.request.id}] 분석 완료")
+        return {
+            'stage': '완료',
+            'progress': 100,
+            'result': result.to_json(),
+        }
+    except Exception as e:
+        print(f"[Celery Task {self.request.id}] 오류 발생: {e}")
+        self.update_state(state='FAILURE', meta={'stage': '오류', 'progress': 0, 'error': str(e)})
+        raise e
+    finally:
+        if os.path.exists(file_path):
+            os.remove(file_path)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -3,9 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Malware Pipeline</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"></script>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
-        #cy {
+        #graph-container {
             width: 100%;
             height: 500px;
             border: 1px solid #ccc;
@@ -16,15 +18,19 @@
 <body>
     <h1>악성코드 분석 파이프라인</h1>
     <a href="/history">분석 이력 보기</a>
-    <input type="file" id="fileInput">
-    <button id="uploadButton">분석 시작</button>
-    <hr>
-    <h2>분석 상태</h2>
-    <ul id="statusLog"></ul>
-    <pre id="results"></pre>
-    <div id="cy"></div>
 
-    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <form id="upload-form" enctype="multipart/form-data" class="mt-3">
+        <input type="file" name="file" required>
+        <button type="submit" class="btn btn-primary">분석 시작</button>
+    </form>
+
+    <div class="progress mt-3" style="display:none; height: 25px;">
+        <div class="progress-bar" role="progressbar" style="width:0%">0%</div>
+    </div>
+
+    <div id="results" class="mt-4"></div>
+    <div id="graph-container"></div>
+
     <script src="/static/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Celery task to run the malware analysis
- modify Flask app to enqueue tasks and provide status endpoint
- poll task status from frontend
- update index page to use new polling UI
- include Celery dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af28e5d94832e9f28bee8ae23bee0