### PR TITLE
Implement Cleanlab labeling pipeline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -232,6 +232,22 @@ def train_rl(
 
 
 @app.command()
+def label_data(
+    config_yaml: Path = typer.Option(Path("configs/run_cleanlab.yaml"), "--config", "-c", help="Cleanlab 설정 파일"),
+):
+    """Run Cleanlab to generate reliable labels for graphs."""
+    if not config_yaml.exists():
+        typer.echo("Config file not found.", err=True)
+        raise typer.Exit(code=1)
+
+    typer.echo("[INFO] Running Cleanlab labeling...")
+    from src.pipelines.labeling.run_cleanlab import main as clean_main
+
+    clean_main(config=str(config_yaml))
+    typer.echo("[DONE] Clean labels generated.")
+
+
+@app.command()
 def describe_code(
     code_file: Path = typer.Option(..., "--code", "-c", help="코드 파일 경로"),
     embed_path: Path = typer.Option(..., "--embed", "-e", help="그래프 임베딩(.pt)"),

--- a/configs/run_cleanlab.yaml
+++ b/configs/run_cleanlab.yaml
@@ -1,0 +1,12 @@
+# Configuration for Cleanlab labeling
+
+data:
+  graph_dir: data/graphs
+  output_path: data/labels/clean_labels.csv
+
+model:
+  encoder_path: models/graphcl_encoder.pt
+  encoder_params: {}
+
+cleanlab:
+  n_splits: 5

--- a/src/pipelines/labeling/run_cleanlab.py
+++ b/src/pipelines/labeling/run_cleanlab.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import numpy as np
+import torch
+from pathlib import Path
+from sklearn.model_selection import StratifiedKFold
+from sklearn.linear_model import LogisticRegression
+from cleanlab.classification import CleanLearning
+import hydra
+from omegaconf import DictConfig
+
+from src.data_proc.dataset_loader import GraphDataset
+from src.models.gnn.graphcl_encoder import GraphCLEncoder
+
+
+def get_embeddings(encoder: GraphCLEncoder, dataset: GraphDataset) -> np.ndarray:
+    """Extract embeddings for an entire dataset using a frozen encoder."""
+    embeddings = []
+    encoder.eval()
+    with torch.no_grad():
+        for sample in dataset:
+            data = sample["data"] if isinstance(sample, dict) else sample
+            emb = encoder(data)
+            embeddings.append(emb.cpu().numpy())
+    return np.vstack(embeddings)
+
+
+def get_pred_probs(embeddings: np.ndarray, labels: np.ndarray, n_splits: int = 5) -> np.ndarray:
+    """Return out-of-sample predicted probabilities via K-fold CV."""
+    skf = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=42)
+    num_classes = len(np.unique(labels))
+    pred_probs = np.zeros((len(labels), num_classes))
+
+    for train_idx, test_idx in skf.split(embeddings, labels):
+        X_train, X_test = embeddings[train_idx], embeddings[test_idx]
+        y_train = labels[train_idx]
+        clf = LogisticRegression(max_iter=200)
+        clf.fit(X_train, y_train)
+        pred_probs[test_idx] = clf.predict_proba(X_test)
+    return pred_probs
+
+
+@hydra.main(config_path="../../../configs", config_name="run_cleanlab", version_base=None)
+def main(cfg: DictConfig) -> None:
+    dataset = GraphDataset(Path(cfg.data.graph_dir))
+    initial_labels = np.array([dataset[i]["y"].item() for i in range(len(dataset))])
+
+    encoder = GraphCLEncoder(**cfg.model.get("encoder_params", {}))
+    encoder.load_state_dict(torch.load(cfg.model.encoder_path, map_location="cpu"))
+
+    embeddings = get_embeddings(encoder, dataset)
+    pred_probs = get_pred_probs(embeddings, initial_labels, cfg.cleanlab.get("n_splits", 5))
+
+    cleaner = CleanLearning(clf=LogisticRegression(max_iter=200))
+    issues = cleaner.find_label_issues(labels=initial_labels, pred_probs=pred_probs)
+
+    files = [f.name for f in dataset.files]
+    df = pd.DataFrame({"file": files, "label": initial_labels})
+    if "is_label_issue" in issues:
+        df = df[~issues["is_label_issue"]]
+
+    out_path = Path(cfg.data.output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, index=False)
+    print(f"Saved cleaned labels to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipelines/train_capability_model.py
+++ b/src/pipelines/train_capability_model.py
@@ -31,10 +31,14 @@ def run(
     print(f"레이블 로딩: {labels_path}")
     try:
         embeddings = torch.load(embeddings_path)
-        labels = torch.load(labels_path)
-        # 레이블이 정수형일 경우 float으로 변환
-        if labels.dtype != torch.float32:
-            labels = labels.float()
+        if labels_path.suffix == ".csv":
+            import pandas as pd
+            df = pd.read_csv(labels_path)
+            labels = torch.tensor(df["label"].values, dtype=torch.float32)
+        else:
+            labels = torch.load(labels_path)
+            if labels.dtype != torch.float32:
+                labels = labels.float()
     except FileNotFoundError as e:
         print(f"오류: 데이터 파일을 찾을 수 없습니다. {e}")
         print("임베딩 생성 파이프라인을 먼저 실행하세요.")
@@ -49,7 +53,7 @@ def run(
 
     # 3. 모델, 손실 함수, 옵티마이저 초기화
     in_dim = embeddings.shape[1]
-    num_labels = labels.shape[1]
+    num_labels = labels.shape[1] if labels.ndim > 1 else 1
     print(f"모델 초기화: 입력 차원={in_dim}, 출력 레이블 수={num_labels}")
 
     model = CapabilityHead(in_dim=in_dim, num_labels=num_labels, adj_path=adj_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,3 +48,10 @@ def test_describe_code_smoke(tmp_path: Path):
     )
     assert result.exit_code == 0
     assert result.stdout.strip()
+
+
+def test_label_data_missing_config(tmp_path: Path):
+    runner = CliRunner()
+    cfg = tmp_path / "missing.yaml"
+    result = runner.invoke(app, ["label-data", "--config", str(cfg)])
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary
- integrate Cleanlab for label generation
- add new CLI command `label-data`
- support CSV labels when training capability model
- provide default configuration for Cleanlab
- test CLI registration of new command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af5260e48832e9c91646ef82db9d1