### PR TITLE
Add unified GNN/Transformer classifier

### DIFF
--- a/configs/train_classifier.yaml
+++ b/configs/train_classifier.yaml
@@ -1,0 +1,36 @@
+# FILE: configs/train_classifier.yaml
+
+defaults:
+  - paths
+  - _self_
+
+# Backbone type: gnn, transformer, or ensemble
+backbone_type: 'ensemble'
+
+model:
+  gnn_encoder:
+    _target_: src.models.gnn.graphcl_encoder.GraphCLEncoder
+    in_dim: 256
+    hidden_dim: 256
+    out_dim: 128
+
+  transformer_encoder:
+    _target_: src.models.transformer.hier_transformer.HierTransformer
+    vocab_size: 32000
+    dim: 256
+    depth: 4
+    num_heads: 8
+
+  ensemble:
+    combination_strategy: 'concat'
+    projection_dim: 256
+
+  capability_head:
+    _target_: src.models.heads.capability_head.CapabilityHead
+    num_labels: 20
+    d_model: 256
+
+training:
+  num_epochs: 10
+  batch_size: 16
+  learning_rate: 1e-3

--- a/src/data_proc/__init__.py
+++ b/src/data_proc/__init__.py
@@ -1,5 +1,6 @@
 from .hdhg_builder import HDHGBuilder
 from .graph_builder import GraphNormalizer
 from .dataset_loader import GraphDataset
+from .unified_dataset import UnifiedDataset
 from .ir_extractor import IRExtractor
 

--- a/src/data_proc/unified_dataset.py
+++ b/src/data_proc/unified_dataset.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Dict
+
+import torch
+from torch.utils.data import Dataset
+from torch_geometric.data import HeteroData, Batch
+
+class UnifiedDataset(Dataset):
+    """Dataset providing graph data, sequence data, and labels together."""
+
+    def __init__(self, root: str):
+        self.root = Path(root)
+        self.graph_dir = self.root / "graphs"
+        self.seq_dir = self.root / "sequences"
+        self.files = sorted(f.stem for f in self.graph_dir.glob("*.pt"))
+
+    def __len__(self) -> int:
+        return len(self.files)
+
+    def __getitem__(self, idx: int) -> Dict:
+        key = self.files[idx]
+        graph_data = torch.load(self.graph_dir / f"{key}.pt")
+        seq = torch.load(self.seq_dir / f"{key}.pt")
+        label = torch.tensor(graph_data.get("label", 0), dtype=torch.float32)
+        if isinstance(graph_data, dict):
+            graph = graph_data["data"]
+        else:
+            graph = graph_data
+        return {
+            "graph_data": graph,
+            "sequence_data": seq,
+            "labels": label,
+        }
+
+    @staticmethod
+    def collate_fn(batch):
+        graphs = [b["graph_data"] for b in batch]
+        seqs = [b["sequence_data"] for b in batch]
+        labels = torch.stack([b["labels"] for b in batch])
+        graph_batch = Batch.from_data_list(graphs)
+        seq_batch = {k: torch.stack([s[k] for s in seqs]) for k in seqs[0]}
+        return {
+            "graph_data": graph_batch,
+            "sequence_data": seq_batch,
+            "labels": labels,
+        }

--- a/src/models/unified_classifier.py
+++ b/src/models/unified_classifier.py
@@ -1,0 +1,69 @@
+import torch
+import torch.nn as nn
+from omegaconf import DictConfig
+import hydra
+
+class UnifiedClassifier(nn.Module):
+    """Wraps GNN, Transformer, or both depending on cfg.backbone_type."""
+
+    def __init__(self, cfg: DictConfig):
+        super().__init__()
+        self.cfg = cfg
+        self.backbone_type = cfg.backbone_type
+
+        self.gnn_encoder = None
+        self.transformer_encoder = None
+
+        if self.backbone_type in ['gnn', 'ensemble']:
+            self.gnn_encoder = hydra.utils.instantiate(cfg.model.gnn_encoder)
+        if self.backbone_type in ['transformer', 'ensemble']:
+            self.transformer_encoder = hydra.utils.instantiate(cfg.model.transformer_encoder)
+
+        self.ensemble_projection = None
+        if self.backbone_type == 'ensemble' and cfg.model.ensemble.combination_strategy == 'concat':
+            gnn_dim = cfg.model.gnn_encoder.out_dim
+            transformer_dim = cfg.model.transformer_encoder.dim
+            self.ensemble_projection = nn.Linear(gnn_dim + transformer_dim, cfg.model.ensemble.projection_dim)
+
+        head_input_dim = self._get_head_input_dim()
+        self.head = hydra.utils.instantiate(cfg.model.capability_head, in_dim=head_input_dim)
+
+    def _get_head_input_dim(self) -> int:
+        if self.backbone_type == 'gnn':
+            return self.cfg.model.gnn_encoder.out_dim
+        if self.backbone_type == 'transformer':
+            return self.cfg.model.transformer_encoder.dim
+        if self.backbone_type == 'ensemble':
+            if self.cfg.model.ensemble.combination_strategy == 'concat':
+                return self.cfg.model.ensemble.projection_dim
+            return self.cfg.model.gnn_encoder.out_dim
+        raise ValueError(f"Unknown backbone_type: {self.backbone_type}")
+
+    def forward(self, batch: dict) -> torch.Tensor:
+        if self.backbone_type == 'gnn':
+            embedding = self.gnn_encoder(batch['graph_data'])
+        elif self.backbone_type == 'transformer':
+            seq = batch['sequence_data']
+            t_out = self.transformer_encoder(
+                input_ids=seq['input_ids'],
+                func_ids=seq['func_ids'],
+                pos_in_func=seq['pos_in_func'],
+            )
+            embedding = t_out.mean(dim=1)
+        else:
+            gnn_emb = self.gnn_encoder(batch['graph_data'])
+            seq = batch['sequence_data']
+            t_out = self.transformer_encoder(
+                input_ids=seq['input_ids'],
+                func_ids=seq['func_ids'],
+                pos_in_func=seq['pos_in_func'],
+            )
+            trans_emb = t_out.mean(dim=1)
+            if self.cfg.model.ensemble.combination_strategy == 'concat':
+                combined = torch.cat([gnn_emb, trans_emb], dim=1)
+                embedding = self.ensemble_projection(combined)
+            else:
+                embedding = (gnn_emb + trans_emb) / 2
+
+        logits = self.head(embedding)
+        return logits

--- a/src/pipelines/train_classifier.py
+++ b/src/pipelines/train_classifier.py
@@ -1,0 +1,41 @@
+import hydra
+from omegaconf import DictConfig
+import torch
+from torch.utils.data import DataLoader
+
+from src.models.unified_classifier import UnifiedClassifier
+from src.data_proc.unified_dataset import UnifiedDataset
+from src.models.losses import AsymmetricLoss
+
+
+@hydra.main(config_path="../../configs", config_name="train_classifier", version_base=None)
+def train_pipeline(cfg: DictConfig) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = UnifiedClassifier(cfg).to(device)
+
+    dataset = UnifiedDataset(root=cfg.paths.data_dir)
+    loader = DataLoader(dataset, batch_size=cfg.training.batch_size, shuffle=True, collate_fn=dataset.collate_fn)
+
+    opt = torch.optim.Adam(model.parameters(), lr=cfg.training.learning_rate)
+    loss_fn = AsymmetricLoss()
+
+    model.train()
+    for epoch in range(cfg.training.num_epochs):
+        total = 0.0
+        for batch in loader:
+            batch = {k: v.to(device) if torch.is_tensor(v) else {kk: vv.to(device) for kk, vv in v.items()} if isinstance(v, dict) else v for k, v in batch.items()}
+            labels = batch['labels']
+            opt.zero_grad()
+            logits = model(batch)
+            loss = loss_fn(logits, labels)
+            loss.backward()
+            opt.step()
+            total += loss.item()
+        avg = total / len(loader)
+        print(f"epoch {epoch}: loss={avg:.4f}")
+
+    torch.save(model.state_dict(), "unified_classifier_final.pt")
+
+
+if __name__ == "__main__":
+    train_pipeline()


### PR DESCRIPTION
## Summary
- add Hydra config to toggle GNN, transformer or ensemble
- implement `UnifiedClassifier` for dynamic backbone selection
- create `UnifiedDataset` to supply graphs and sequences
- provide training pipeline `train_classifier.py`
- expose dataset in package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af7dbbf28832ebcb7261feb9d7fbc