### PR TITLE
Enable async analysis tasks and PDF export

### DIFF
--- a/configs/celery.yaml
+++ b/configs/celery.yaml
@@ -1,0 +1,2 @@
+CELERY_BROKER_URL: 'redis://localhost:6379/0'
+CELERY_RESULT_BACKEND: 'redis://localhost:6379/0'

--- a/web/app.py
+++ b/web/app.py
@@ -10,9 +10,7 @@ from werkzeug.utils import secure_filename
 from weasyprint import HTML
 from flask_sqlalchemy import SQLAlchemy
 
-from src.pipelines.orchestrator import DetectionOrchestrator
-
-# Celery task import
+from .tasks import run_analysis_task
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'your-secret-key'
@@ -22,11 +20,7 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///malware_analysis.db'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)
 
-# Instantiate detection orchestrator once at startup
-orchestrator = DetectionOrchestrator()
-
-# SocketIO instance setup (not used for results push)
-# pipeline_wrapper.set_socketio(socketio)
+# SocketIO instance setup for progress updates
 
 
 class Analysis(db.Model):
@@ -88,22 +82,14 @@ def upload_file():
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
         file.save(filepath)
 
-        # Directly run detection using the loaded orchestrator
-        result = orchestrator.run_detection(filepath)
-
-        # Persist result in DB
-        analysis = Analysis(
-            filename=filename,
-            status='complete',
-            report_json=json.dumps(result.to_json())
-        )
+        analysis = Analysis(filename=filename, status='pending')
         db.session.add(analysis)
         db.session.commit()
 
-        # Clean up uploaded file
-        os.remove(filepath)
+        session_id = request.form.get('session_id') or ''
+        run_analysis_task.delay(filepath, session_id, analysis.id)
 
-        return jsonify({'success': True, 'analysis_id': analysis.id, 'result': result.to_json()})
+        return jsonify({'message': 'Analysis started.', 'analysis_id': analysis.id})
 
 
 
@@ -116,17 +102,17 @@ def view_report(analysis_id):
     if analysis.report_json:
         report_data = json.loads(analysis.report_json)
 
-    return render_template('report.html', report=report_data)
+    return render_template('report.html', report=report_data, for_pdf=False)
 
 
-@app.route('/report/pdf/<int:analysis_id>')
-def download_pdf_report(analysis_id):
+@app.route('/report/<int:analysis_id>/export_pdf')
+def export_report_pdf(analysis_id):
     """보고서 페이지를 PDF로 변환하여 다운로드"""
     analysis = Analysis.query.get_or_404(analysis_id)
     report_data = {}
     if analysis.report_json:
         report_data = json.loads(analysis.report_json)
-    html_string = render_template('report.html', report=report_data)
+    html_string = render_template('report.html', report=report_data, for_pdf=True)
 
     # WeasyPrint를 사용하여 HTML을 PDF로 변환
     pdf = HTML(string=html_string).write_pdf()

--- a/web/pipeline_wrapper.py
+++ b/web/pipeline_wrapper.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any
+from typing import Any, Callable
 
 from flask_socketio import SocketIO
 
@@ -11,6 +11,21 @@ socketio: SocketIO | None = None
 def set_socketio(sio: SocketIO) -> None:
     global socketio
     socketio = sio
+
+
+class SocketIOWrapper:
+    """Send progress updates via SocketIO and optionally update Celery."""
+
+    def __init__(self, sio: SocketIO, session_id: str, task: Any | None = None):
+        self.sio = sio
+        self.session_id = session_id
+        self.task = task
+
+    def __call__(self, message: str, percentage: int) -> None:
+        if self.task is not None:
+            self.task.update_state(state="PROGRESS", meta={"status": message, "percentage": percentage})
+        if self.sio is not None:
+            self.sio.emit("progress", {"status": message, "percentage": percentage}, room=self.session_id)
 
 
 class PipelineWrapper:

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1,11 +1,20 @@
 $(document).ready(function() {
-    $('#upload-form').on('submit', function(e) {
-        e.preventDefault();
-        var formData = new FormData(this);
+    const socket = io();
+    let sessionId = null;
 
-        // 초기화 및 로딩 표시
+    socket.on('connect', function() {
+        sessionId = socket.id;
+    });
+
+    $('#upload-form').on('submit', function(event) {
+        event.preventDefault();
+        var formData = new FormData(this);
+        formData.append('session_id', sessionId);
+
         $('#results').empty();
         $('#graph-container').empty();
+        $('#progress-bar').css('width', '0%').text('0%');
+        $('#status-text').text('Uploading file...');
         $('.progress').show();
 
         $.ajax({
@@ -14,16 +23,25 @@ $(document).ready(function() {
             data: formData,
             processData: false,
             contentType: false,
-            success: function(data) {
-                if (data.success) {
-                    $('.progress-bar').css('width', '100%').text('완료');
-                    displayResults(data.result);
-                }
+            success: function(response) {
+                $('#status-text').text('Analysis in progress...');
+                console.log('Task started:', response.analysis_id);
             },
             error: function() {
                 alert('파일 업로드에 실패했습니다.');
             }
         });
+    });
+
+    socket.on('progress', function(data) {
+        const percentage = data.percentage || 0;
+        $('#progress-bar').css('width', percentage + '%').text(percentage + '%');
+        $('#status-text').text(data.status);
+    });
+
+    socket.on('analysis_complete', function(data) {
+        $('#status-text').text('Analysis complete. Redirecting...');
+        window.location.href = data.report_url;
     });
 });
 

--- a/web/tasks.py
+++ b/web/tasks.py
@@ -1,52 +1,38 @@
 import os
+import yaml
 from celery import Celery
 from celery.utils.log import get_task_logger
-from src.common.config import load_config
-from src.pipelines.orchestrator import Orchestrator as RealOrchestrator
-from .pipeline_wrapper import PipelineWrapper
+from src.pipelines.orchestrator import DetectionOrchestrator
+from .pipeline_wrapper import SocketIOWrapper
+from .app import socketio, update_analysis_result
 
-celery_app = Celery(
-    'web.tasks',
-    broker='redis://localhost:6379/0',
-    backend='redis://localhost:6379/1'
-)
+with open(os.path.join(os.path.dirname(__file__), '..', 'configs', 'celery.yaml')) as f:
+    celery_cfg = yaml.safe_load(f)
+
+celery_app = Celery('web.tasks')
+celery_app.conf.broker_url = celery_cfg.get('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+celery_app.conf.result_backend = celery_cfg.get('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0')
 
 logger = get_task_logger(__name__)
 
 
 @celery_app.task(bind=True)
-def run_analysis_task(self, file_path: str):
+def run_analysis_task(self, file_path: str, session_id: str, analysis_id: int | None = None):
     """Run the malware analysis pipeline in a Celery worker."""
-    session_id = self.request.id
 
-    def progress(stage: str, pct: int) -> None:
-        self.update_state(state="PROGRESS", meta={"stage": stage, "progress": pct})
+    progress_wrapper = SocketIOWrapper(socketio, session_id, task=self)
 
     try:
-        logger.info("Loading base config for task %s", session_id)
-        config = load_config("configs/pipelines/detect.yaml")
-        config.paths.target_path = file_path
-        upload_dir = os.path.dirname(file_path)
-        config.paths.output_dir = os.path.join(upload_dir, "results")
-        os.makedirs(config.paths.output_dir, exist_ok=True)
+        logger.info("Loading config for task %s", session_id)
+        orchestrator = DetectionOrchestrator("configs/pipelines/detect.yaml")
+        result = orchestrator.run_detection(file_path, progress_callback=progress_wrapper)
 
-        logger.info("Initializing RealOrchestrator for task %s", session_id)
-        orchestrator = RealOrchestrator(config)
-        wrapper = PipelineWrapper(session_id, orchestrator)
+        if analysis_id is not None:
+            update_analysis_result(analysis_id, "complete", result.to_json())
 
-        progress("IR 추출", 10)
-        wrapper.run_step("extract_ir", "IR 추출 중...")
-
-        progress("그래프 생성", 40)
-        wrapper.run_step("build_graph", "그래프 생성 중...")
-
-        progress("악성 행위 탐지", 70)
-        wrapper.run_step("detect", "악성 행위 탐지 중...")
-
-        report_data = orchestrator.get_results()
-        wrapper.save_and_finalize_report(report_data)
+        socketio.emit('analysis_complete', {'report_url': f'/report/{analysis_id}'}, room=session_id)
         logger.info("Analysis complete for task %s", session_id)
-        return {"stage": "완료", "progress": 100, "result": report_data}
+        return {"status": "Complete", "report_id": analysis_id}
 
     except Exception as e:
         logger.error("Error in analysis task %s: %s", session_id, e, exc_info=True)

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Malware Pipeline</title>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.5.4/socket.io.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.28.1/cytoscape.min.js"></script>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <style>
@@ -25,8 +26,9 @@
     </form>
 
     <div class="progress mt-3" style="display:none; height: 25px;">
-        <div class="progress-bar" role="progressbar" style="width:0%">0%</div>
+        <div id="progress-bar" class="progress-bar" role="progressbar" style="width:0%">0%</div>
     </div>
+    <p id="status-text" class="mt-2"></p>
 
     <div id="results" class="mt-4"></div>
     <div id="graph-container"></div>

--- a/web/templates/report.html
+++ b/web/templates/report.html
@@ -7,9 +7,13 @@
 </head>
 <body>
     <h1>분석 보고서: {{ report.sample_id }}</h1>
-    <a href="/report/pdf/{{ report.sample_id }}">
-        <button>PDF로 저장</button>
-    </a>
+    {% if not for_pdf %}
+    <div class="export-container" style="margin: 20px; text-align: right;">
+        <a href="{{ url_for('export_report_pdf', analysis_id=report.sample_id) }}" class="btn btn-primary">
+            Export to PDF
+        </a>
+    </div>
+    {% endif %}
     <hr>
     <h2>주요 지표</h2>
     <ul>


### PR DESCRIPTION
## Summary
- configure Celery via new `configs/celery.yaml`
- add `SocketIOWrapper` for progress callbacks
- run analysis asynchronously in `/upload` using Celery
- provide PDF export route with `for_pdf` flag
- update front-end to show realtime progress via Socket.IO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b14061f80832ea35dd3ffa3e5d40c