### PR TITLE
Add tests for models and RL environment

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,30 @@
+import pytest
+
+# Skip if PyTorch not available
+torch = pytest.importorskip("torch")
+
+from src.models.transformer.hier_transformer import HierTransformer
+
+
+def test_hier_transformer_initialization_and_forward_pass():
+    """Model should initialize and return correct output shape."""
+    vocab_size = 50
+    model = HierTransformer(
+        vocab_size=vocab_size,
+        dim=32,
+        depth=2,
+        num_heads=4,
+        window_size=8,
+    )
+    model.eval()
+
+    batch, seq_len = 4, 16
+    input_ids = torch.randint(0, vocab_size, (batch, seq_len))
+    func_ids = torch.zeros(batch, seq_len, dtype=torch.long)
+    pos_in_func = torch.arange(seq_len).repeat(batch, 1)
+
+    with torch.no_grad():
+        out = model(input_ids, func_ids, pos_in_func)
+
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == (batch, seq_len, model.dim)

--- a/tests/test_rl_env.py
+++ b/tests/test_rl_env.py
@@ -1,0 +1,91 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+# Required third-party libs
+pytest.importorskip("gymnasium")
+pytest.importorskip("yara")
+torch = pytest.importorskip("torch")
+
+from src.models.rl.env.rule_env import RuleEnv, RLConfig
+from src.models.rl.env.action_space import ActionSpec, AT
+from src.models.rl.env.reward.components import Conciseness
+from src.models.rl.env.reward.context import RewardContext
+from src.rules.rule_builder import RuleBuilder
+import numpy as np
+
+
+def _dummy_validator():
+    class V:
+        pass
+    return V()
+
+
+def test_conciseness_reward():
+    """Conciseness component should penalize long rules."""
+    builder = RuleBuilder()
+    builder.add_literal("foo")
+    ctx = RewardContext(
+        builder=builder,
+        validator=_dummy_validator(),
+        features_seen=set(),
+        cfg=SimpleNamespace(max_strings=5),
+        malware_paths=[],
+        benign_paths=[],
+    )
+    comp = Conciseness(weight=1.0)
+    reward = comp(ctx)
+    assert reward == pytest.approx(1 - 1 / 5)
+
+
+@pytest.fixture
+def rule_env(tmp_path):
+    features = {
+        "func": {
+            "embedding": [0.0] * 8,
+            "features": {"apis": ["CreateFileW"], "strings": []},
+        }
+    }
+    feat_file = tmp_path / "feat.json"
+    feat_file.write_text(json.dumps(features))
+
+    mal_dir = tmp_path / "mal"
+    ben_dir = tmp_path / "ben"
+    mal_dir.mkdir()
+    ben_dir.mkdir()
+    (mal_dir / "m.bin").write_bytes(b"m")
+    (ben_dir / "b.bin").write_bytes(b"b")
+
+    cfg = RLConfig(max_strings=3, max_edit=2, rule_emb_dim=8)
+    return RuleEnv(feat_file, ben_dir, mal_dir, cfg=cfg)
+
+
+def test_env_step_and_state_transition(rule_env):
+    obs, _ = rule_env.reset(seed=0)
+    start_rule = rule_env.state.builder.build()
+
+    action = rule_env.mapper.encode(ActionSpec(AT.ADD_LIT, 0))
+    obs2, reward, done, truncated, _ = rule_env.step(action)
+    new_rule = rule_env.state.builder.build()
+
+    assert isinstance(obs2, np.ndarray)
+    assert obs2.shape == (rule_env._obs_dim,)
+    assert new_rule != start_rule
+    assert reward.shape == (len(rule_env.reward_pipe.comps),)
+    assert done is False and truncated is False
+
+
+def test_env_termination_by_max_steps(rule_env):
+    rule_env.reset()
+    # need one literal first
+    rule_env.step(rule_env.mapper.encode(ActionSpec(AT.ADD_LIT, 0)))
+    action = rule_env.mapper.encode(ActionSpec(AT.ADD_Q, 0))
+
+    done = False
+    for i in range(rule_env.cfg.max_edit):
+        _, _, done, _, _ = rule_env.step(action)
+        if i < rule_env.cfg.max_edit - 1:
+            assert not done
+
+    assert done


### PR DESCRIPTION
## Summary
- add a smoke test for `HierTransformer` forward pass
- add unit tests for RL `Conciseness` reward component
- add RL environment integration tests with dummy data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c445c089c832ea0ac98ca05f2ec5b